### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Fix `NameError: undefined local variable or method `config` for Rails RSpec
   configuration (Aaron Kromer, #1)
+- Fix model factory build issue in which registered template attributes, which
+  use symbol keys, are not replaced by custom attributes using string keys
+  (Aaron Kromer, #1)
 
 
 ## 0.1.0 (March 14, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Bug Fixes
 
-- TODO
+- Fix `NameError: undefined local variable or method `config` for Rails RSpec
+  configuration (Aaron Kromer, #1)
 
 
 ## 0.1.0 (March 14, 2018)

--- a/README.md
+++ b/README.md
@@ -52,9 +52,18 @@ custom RSpec configuration in a `RSpec.configure` block as usual:
 require 'radius/spec'
 
 RSpec.configure do |config|
+  # Project's with noisy dependencies, and Rails app, include this line to
+  # disable warnings.
+  config.warnings = false
+
   # Your project specific custom settings here
 end
 ```
+
+**NOTE:** By default warnings are enabled by this gem. Enabling Ruby warnings
+is generally recommended. However, for large projects, and including most Rails
+apps, with lots of noisy dependencies this can be an issue. For these projects,
+we suggest disabling warnings per the above method.
 
 For Rails apps, we suggest a similar approach to your Rails helper:
 

--- a/lib/radius/spec/model_factory.rb
+++ b/lib/radius/spec/model_factory.rb
@@ -254,6 +254,17 @@ module Radius
         alias_method :factory, :define_factory
 
         # @private
+        def merge_attrs(template, custom_attrs)
+          template_only = template.keys - custom_attrs.keys
+          template.slice(*template_only)
+                  .delete_if { |_, v| :optional == v }
+                  .transform_values! { |v|
+                    ::Radius::Spec::ModelFactory.safe_transform(v)
+                  }
+                  .merge(custom_attrs)
+        end
+
+        # @private
         def safe_transform(value)
           return value.call if value.is_a?(Proc)
           return value if value.frozen?
@@ -408,13 +419,7 @@ module Radius
         name = name.to_s
         template = ::Radius::Spec::ModelFactory.template(name)
         custom_attrs = custom_attrs.transform_keys(&:to_sym)
-        template_only = template.keys - custom_attrs.keys
-        attrs = template.slice(*template_only)
-                        .delete_if { |_, v| :optional == v }
-                        .transform_values! { |v|
-                          ::Radius::Spec::ModelFactory.safe_transform(v)
-                        }
-                        .merge(custom_attrs)
+        attrs = ::Radius::Spec::ModelFactory.merge_attrs(template, custom_attrs)
         # TODO: Always yield to the provided block even if new doesn't
         ::Object.const_get(name).new(attrs, &block)
       end

--- a/lib/radius/spec/model_factory.rb
+++ b/lib/radius/spec/model_factory.rb
@@ -407,6 +407,7 @@ module Radius
       def build(name, custom_attrs = {}, &block)
         name = name.to_s
         template = ::Radius::Spec::ModelFactory.template(name)
+        custom_attrs = custom_attrs.transform_keys(&:to_sym)
         template_only = template.keys - custom_attrs.keys
         attrs = template.slice(*template_only)
                         .delete_if { |_, v| :optional == v }

--- a/lib/radius/spec/rails.rb
+++ b/lib/radius/spec/rails.rb
@@ -5,7 +5,7 @@ require 'radius/spec'
 require 'radius/spec/rspec'
 require 'rspec/rails'
 
-RSpec.configure do
+RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = ::Rails.root.join("spec", "fixtures")
 

--- a/spec/radius/spec/model_factory_spec.rb
+++ b/spec/radius/spec/model_factory_spec.rb
@@ -237,6 +237,32 @@ RSpec.describe Radius::Spec::ModelFactory do
       )
     end
 
+    it "supports custom attributes with string keys (converting to symbols)" do
+      stub_const(
+        "AnyClass",
+        Class.new {
+          def initialize(attrs)
+            @attrs = attrs
+          end
+          attr_reader :attrs
+        },
+      )
+      Radius::Spec::ModelFactory.define_factory(
+        "AnyClass",
+        arg1: "Any Default Arg1 Value",
+        arg2: "Any Default Arg2 Value",
+      )
+
+      an_instance = Radius::Spec::ModelFactory.build(
+        "AnyClass",
+        "arg1" => "Custom Value",
+      )
+      expect(an_instance.attrs).to eq(
+        arg1: "Custom Value",
+        arg2: "Any Default Arg2 Value",
+      )
+    end
+
     it "duplicates registered attributes to prevent state leak " \
        "between instances", :aggregate_failures do
       mutable_array = %i[any value]

--- a/spec/radius/spec/model_factory_spec.rb
+++ b/spec/radius/spec/model_factory_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe Radius::Spec::ModelFactory do
       expect(an_instance.arg).to eq :custom
     end
 
-    it "pass any provided block to the object's initializer" do
+    it "passes any provided block to the object's initializer" do
       block_initialized = false
       stub_const(
         "AnyClass",


### PR DESCRIPTION
## Fix error with Rails RSpec configuration

This fixes the following error:

    NameError:
      undefined local variable or method `config' for main:Object

Not sure how this slipped past the initial round of external testing. Since we don't have a setup for integration/acceptance testing the Rails specific code parts yet it's not surprising something like this slipped through. Though it is proof that we should include a way to perform automated Rails integration testing.


## Fix model factory building custom string key attrs

The existing model factory supports registering templates with either string or symbol keys. The factory converts all keys to symbols for consistency. This means when a model instance is built using the factory the expectation is that symbol keys will be provided. Further, when building a model with custom attributes the expectation is that the custom attributes overwrite the registered template prior to the model initialization.

### Issue

The following model class fails to see custom attributes defined using string keys:

  ```ruby
  class Foo
    def initialize(attrs = {})
      @something = attrs.fetch(:something)
    end

    # ...
  end
  ```

### Cause

The :bug: is caused due to the builder not converting the custom attribute keys into symbols. Thus the model is sent a hash which contains a combination of string and symbol keys:

  ```ruby
  {
    :something    => "any_value",
    :another_attr => "another_value",
    "something"   => "custom_value",
  }
  ```

While we did not have a test specifically covering the message passing contract, the existing test _"merges the custom attributes with the registered ones"_ will pass even if we changed the custom attributes to use string keys. This is because Ruby, in an effort to support backwards compatibility for older code upgrading to kwargs, is "kind" enough to treat the string key as a kwarg. And since Ruby hashes are ordered, and the string key appears last, it is used as the kwarg.