### PR TITLE
Include new common Rubocop customizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: ruby
 cache: bundler
+before_install:
+  - gem update --system
+  - gem install bundler
 bundler_args: --jobs=3 --retry=3 --without documentation debug
 script: bin/ci
 rvm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Allow unspecified rescue as a catch-all
 - Adjust common Rubocop Rails configuration (Aaron Kromer, #2):
   - Ignore `Rails/ApplicationRecord` for benchmarks
+  - Ignore more common gem binstubs
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Enhancements
 
-- TODO
+- Adjust common Rubocop configuration (Aaron Kromer, #2):
+  - Ignore `Lint/AmbiguousBlockAssociation` for specs
+  - Ignore long lines due to Rubocop directives
+  - Disable ASCII only comments
+  - Set the `MinSize` for `Style/SymbolArray` and `Style/WordArray` to three
+- Adjust common Rubocop Rails configuration (Aaron Kromer, #2):
+  - Ignore `Rails/ApplicationRecord` for benchmarks
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@
 - Adjust common Rubocop configuration (Aaron Kromer, #2):
   - Ignore `Lint/AmbiguousBlockAssociation` for specs
   - Ignore long lines due to Rubocop directives
+  - Ignore long lines due to comments
+  - Prefer a line length of 80, but don't complain until 90
   - Disable ASCII only comments
   - Set the `MinSize` for `Style/SymbolArray` and `Style/WordArray` to three
+  - Use squiggly `<<~` heredoc indentation
+  - Allow common `EOF` as a heredoc delimiter
+  - Indent multi-line operations
+  - Allow unspecified rescue as a catch-all
 - Adjust common Rubocop Rails configuration (Aaron Kromer, #2):
   - Ignore `Rails/ApplicationRecord` for benchmarks
 

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -111,9 +111,7 @@ Metrics/BlockLength:
     - 'spec/support/model_factories.rb'
 
 # We generally prefer to use the default line length of 80. Though sometimes
-# you just need a little extra space because it is easier to read the code on
-# one line instead of several. This sets the max to 90 to allow a little extra
-# room (though we'd probably prefer to get this to ~85).
+# we just need a little extra space because it makes it easier to read.
 #
 # The only way to disable Rubocop for a single line is either to wrap the line
 # with two comments or append the disable comment to the end of the line. For
@@ -143,7 +141,7 @@ Metrics/LineLength:
     - '\A\s*#'
     # Attempt at trailing comments
     - '\A.{1,78}\s#\s.*\z'
-  Max: 90
+  Max: 100
 
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -51,6 +51,28 @@ Layout/ClosingParenthesisIndentation:
 Layout/FirstParameterIndentation:
   Enabled: false
 
+# In our specs Rubocop inconsistently complains when using the block form of
+# `expect` and `change`. It accepts code when a method is chained onto
+# `change`, but otherwise it complains. Since this is a widely used pattern in
+# our specs we just tell Rubocop to ignore our spec files.
+#
+#     # Acceptable to Rubocop
+#     expect {
+#       some_action
+#     }.to change {
+#       object.state
+#     }.from(:original).to(:updated)
+#
+#     # Rubocop complains
+#     expect {
+#       some_action
+#     }.to change {
+#       object.state
+#     }
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
 # Often with benchmarking we don't explictly "use" a variable or return value.
 # We simply need to perform the operation which generates said value for the
 # benchmark.
@@ -69,6 +91,19 @@ Metrics/BlockLength:
     - 'spec/**/*_spec.rb'
     - 'spec/support/model_factories.rb'
 
+# Ignore long lines caused by Rubocop comments
+#
+# The only way to disable Rubocop for a single line is either to wrap the line
+# with two comments or append the disable comment to the end of the line. For
+# guard clauses, we tend to prefer the longer line so that the comment wraps
+# don't take away from the method flow. Since these are our only options we'll
+# accept the longer lines cause because of Rubocop's own semantics.
+#
+# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
+# URISchemes: http, https
+Metrics/LineLength:
+  IgnoreCopDirectives: true
+
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
 Naming/FileName:
@@ -86,6 +121,13 @@ Naming/FileName:
 # SupportedStyles: prefer_alias, prefer_alias_method
 Style/Alias:
   EnforcedStyle: prefer_alias_method
+
+# These days most people have editors which support unicode and other
+# non-ASCII characters.
+#
+# Configuration parameters: AllowedChars.
+Style/AsciiComments:
+  Enabled: false
 
 # Use semantic style for blocks:
 #   - Prefer `do...end` over `{...}` for procedural blocks.
@@ -224,6 +266,18 @@ Style/RegexpLiteral:
 Style/StringLiterals:
   Enabled: false
 
+# We don't feel too strongly about percent vs bracket array style. We tend to
+# use the percent style, which also happens to be Rubocop's default. So for
+# pedantic consistency we'll enforce this.
+#
+# However, as we don't feel that strongly about this we'll increase the
+# minimum size to 3 to allow very small arrays to exist either way.
+#
+# Configuration parameters: EnforcedStyle, MinSize.
+# SupportedStyles: percent, brackets
+Style/SymbolArray:
+  MinSize: 3
+
 # When ternaries become complex they can be difficult to read due to increased
 # cognative load parsing the expression. Cognative load can increase further
 # when assignment is involved.
@@ -281,6 +335,18 @@ Style/TrailingCommaInHashLiteral:
     easier to read by cutting down on noise when commas are appended. It also
     simplifies adding, removing, and re-arranging the elements.
   EnforcedStyleForMultiline: consistent_comma
+
+# We don't feel too strongly about percent vs bracket array style. We tend to
+# use the percent style, which also happens to be Rubocop's default. So for
+# pedantic consistency we'll enforce this.
+#
+# However, as we don't feel that strongly about this we'll increase the
+# minimum size to 3 to allow very small arrays to exist either way.
+#
+# Configuration parameters: EnforcedStyle, MinSize, WordRegex.
+# SupportedStyles: percent, brackets
+Style/WordArray:
+  MinSize: 3
 
 # When it comes to constants it's safer to place the constant on the right-hand
 # side. With a constant accidental assignment will produce a syntax error.

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -51,6 +51,25 @@ Layout/ClosingParenthesisIndentation:
 Layout/FirstParameterIndentation:
   Enabled: false
 
+# This project only uses newer Ruby versions which all support the "squiggly"
+# style. We prefer to use pure Ruby calls when possible instead of relying on
+# alternatives; even for Rails app.
+#
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
+Layout/IndentHeredoc:
+  EnforcedStyle: squiggly
+
+# We tend to indent multi-line operation statements. I think this is because
+# it's tends to be the default style auto-formatted by VIM (which many of us
+# use). It also helps show the continuation of the statement instead of it
+# potentially blending in with the start of the next statement.
+#
+# Configuration parameters: EnforcedStyle, IndentationWidth.
+# SupportedStyles: aligned, indented
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
 # In our specs Rubocop inconsistently complains when using the block form of
 # `expect` and `change`. It accepts code when a method is chained onto
 # `change`, but otherwise it complains. Since this is a widely used pattern in
@@ -91,18 +110,40 @@ Metrics/BlockLength:
     - 'spec/**/*_spec.rb'
     - 'spec/support/model_factories.rb'
 
-# Ignore long lines caused by Rubocop comments
+# We generally prefer to use the default line length of 80. Though sometimes
+# you just need a little extra space because it is easier to read the code on
+# one line instead of several. This sets the max to 90 to allow a little extra
+# room (though we'd probably prefer to get this to ~85).
 #
 # The only way to disable Rubocop for a single line is either to wrap the line
 # with two comments or append the disable comment to the end of the line. For
-# guard clauses, we tend to prefer the longer line so that the comment wraps
-# don't take away from the method flow. Since these are our only options we'll
-# accept the longer lines cause because of Rubocop's own semantics.
+# guard clauses, we tend to prefer trailing comments to avoid adding two lines
+# just to disable a cop on one line.
 #
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
+# Sometimes comments include ASCII diagrams, flow charts, etc. These cannot
+# always be reformatted to fit within the 80 column limit. Also, we write most
+# comments in markdown format. Rubocop isn't very good at understanding when
+# the line is long because of a URL in a markdown link. Instead of requiring
+# additional comments to turn this cop off for comments we ignore any long
+# lines which are only comments.
+#
+# There are also cases where for one valid reason or another we have a trailing
+# comment that extends a little too far. We'd like to be able to ignore those
+# as well. This _attempts_ to do that, however, as this uses simple regular
+# expressions we can only attempt to match so much. We probably should change
+# this for a node pattern matcher in the future.
+#
+# Configuration parameters: AllowHeredoc, AllowURI, URISchemes,
+#                           IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
   IgnoreCopDirectives: true
+  IgnoredPatterns:
+    # Leading comments
+    - '\A\s*#'
+    # Attempt at trailing comments
+    - '\A.{1,78}\s#\s.*\z'
+  Max: 90
 
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
@@ -111,6 +152,18 @@ Naming/FileName:
     - '**/Gemfile'
     - '**/*.gemspec'
     - '**/Brewfile'
+
+# This allows `EOF` as the only `EO*` variant.
+#
+# `EOF` is a common terminal abbreviate indicating end-of-file. We allow this
+# for those heredocs which represent "file" text.
+#
+# Configuration parameters: Blacklist.
+# Blacklist: END, (?-mix:EO[A-Z]{1})
+Naming/HeredocDelimiterNaming:
+  Blacklist:
+    - 'END'
+    - '(?-mix:EO[A-EG-Z]{1})'
 
 # `alias` behavior changes on scope. In general we expect the behavior to be
 # that which is defined by `alias_method`.
@@ -256,6 +309,47 @@ Style/NumericPredicate:
 # SupportedStyles: slashes, percent_r, mixed
 Style/RegexpLiteral:
   EnforcedStyle: mixed
+
+# If you only need to rescue a single, or predefined set of exceptions, then
+# catch the exceptions explicitly. However, when you need to include a general
+# error handler / "catch-all" use the "unspecified rescue".
+#
+# Using the unspecified `rescue` on blocks is common Ruby practice. It is a
+# core feature of the language which has semantic meaning. The Rubocop docs do
+# not provide much justification for defaulting to an explicit style and there
+# is no real mention of this in the associated style guide except the following
+# buried in an example for [_Avoid rescuing the `Exception`
+# class_](https://github.com/bbatsov/ruby-style-guide#no-blind-rescues) though
+# the anchor suggests this is for "no blind rescues":
+#
+# > # a blind rescue rescues from StandardError, not Exception as many
+# > # programmers assume.
+#
+# Our general rule for Ruby exceptions is to create your custom errors from
+# `StandardError`. Creating custom errors off of `Exception` is reserved for
+# special edge cases where you don't intend for someone to normally catch it
+# (such as system resource issues; e.g. `NoMemoryError`, `SecurityError`).
+#
+# With that in mind, we can make the same counter argument that since
+# programmers generally assume the unspecified rescue rescues `Exception`,
+# which they normally should not be rescuing, system errors are more likely to
+# noticed.
+#
+# Additionally, use of the unspecified rescue looks and behaves like a
+# "catch-all" or the `else` clause in a `case` statement:
+#
+#   begin
+#     # do something that may cause a standard error
+#   rescue TypeError
+#     handle_type_error
+#   rescue => e
+#     handle_error e
+#   end
+#
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: implicit, explicit
+Style/RescueStandardError:
+  EnforcedStyle: implicit
 
 # We generally prefer double quotes but many generators use single quotes. We
 # don't view the performance difference to be all that much so we don't care

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -11,9 +11,11 @@ Rails:
 AllCops:
   Exclude:
     - 'bin/puma'
+    - 'bin/pumactl'
     - 'bin/rails'
     - 'bin/shoryuken'
     - 'bin/sidekiq'
+    - 'bin/sidekiqctl'
     - 'bin/spring'
     - 'db/schema.rb'
     - 'db/migrate/**/*'

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -36,6 +36,17 @@ Metrics/LineLength:
     - '\A#  fk_rails_'
     - '\A#  index_'
 
+# Ignore subclass parent for one off benchmarks
+#
+# Benchmarks are generally meant to be small and targeted. They often have
+# custom model declarations which help direct the focus of the benchmarks.
+# These one-off models exist outside of the main Rails app. We don't want this
+# cop to run for them because including `ApplicationRecord` is unnecessary in
+# these cases and just adds noise to the setup.
+Rails/ApplicationRecord:
+  Exclude:
+    - 'benchmarks/**/*'
+
 # As Rails defaults to creating timestamps you need to go out of your way to
 # explicitly have them removed from the table. This cop is almost always a
 # false negative so we're disabling it.


### PR DESCRIPTION
These come from working through one of our Rails apps. The changes here are generic enough that they should be applied to all of our projects.

- Adjust common Rubocop configuration
  - Ignore `Lint/AmbiguousBlockAssociation` for specs
  - Ignore long lines due to Rubocop directives
  - Ignore long lines due to comments
  - Prefer a line length of 80, but don't complain until 90
  - Disable ASCII only comments
  - Set the `MinSize` for `Style/SymbolArray` and `Style/WordArray` to three
  - Use squiggly `<<~` heredoc indentation
  - Allow common `EOF` as a heredoc delimiter
  - Indent multi-line operations
  - Allow unspecified rescue as a catch-all
- Adjust common Rubocop Rails configuration
  - Ignore `Rails/ApplicationRecord` for benchmarks
  - Ignore more common gem binstubs

Resolve #3 