### PR TITLE
 Fix warning about overriding parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_mode:
   merge:
     - Exclude
+    - IgnoredPatterns
 
 inherit_from: common_rubocop.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- TODO
+-  Fix warning about overriding parameter (Aaron Kromer, #4)
 
 
 ## 0.2.0 (May 17, 2018)

--- a/README.md
+++ b/README.md
@@ -92,11 +92,20 @@ end
 
 ### Common Rubocop Config
 
-Projects can inherit from the [base Rubocop config](.rubocop.yml) by using
-either the remote raw URL or dependency gem formats:
+Projects can inherit from the [base Rubocop config](.rubocop.yml). This can be
+accomplished by using either the remote raw URL or dependency gem formats. With
+either method we also strongly suggest setting the `inherit_mode` to `merge`
+for both `Exclude` and `IgnoredPatterns`. This way you can append additional
+exceptions without overwriting the defaults.
+
+#### Inherit from Gem (Recommended Method)
 
 ```yaml
-# Recommended Method
+inherit_mode:
+  merge:
+    - Exclude
+    - IgnoredPatterns
+
 inherit_gem:
   radius-spec:
     - common_rubocop.yml
@@ -104,7 +113,14 @@ inherit_gem:
     - common_rubocop_rails.yml
 ```
 
+#### Inherit from URL
+
 ```yaml
+inherit_mode:
+  merge:
+    - Exclude
+    - IgnoredPatterns
+
 # Available for projects which cannot include this gem (i.e. Ruby < 2.5)
 inherit_from:
   - https://raw.githubusercontent.com/RadiusNetworks/radius-spec/master/common_rubocop.yml
@@ -119,6 +135,8 @@ When using the raw URL you may need to add the following to the project's
 .rubocop-https---raw-githubusercontent-com-RadiusNetworks-radius-spec-master-common-rubocop-rails-yml
 .rubocop-https---raw-githubusercontent-com-RadiusNetworks-radius-spec-master-common-rubocop-yml
 ```
+
+#### General Inheritance Notes
 
 Be sure to include the project's local `.rubocop_todo.yml` **after** inheriting
 the base configuration so that they take precedence. Also, use the directive
@@ -137,6 +155,7 @@ inherit_from: .rubocop_todo.yml
 inherit_mode:
   merge:
     - Exclude
+    - IgnoredPatterns
 
 Style/For:
   inherit_mode:

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -1,6 +1,7 @@
 inherit_mode:
   merge:
     - Exclude
+    - IgnoredPatterns
 
 inherit_from: common_rubocop.yml
 

--- a/spec/radius/spec/model_factory_spec.rb
+++ b/spec/radius/spec/model_factory_spec.rb
@@ -444,7 +444,6 @@ RSpec.describe Radius::Spec::ModelFactory do
         arg3: :additional_value,
       }
 
-      # rubocop:disable Metrics/LineLength
       an_instance = nil
       expect {
         an_instance = Radius::Spec::ModelFactory.create("AnyClass", custom_attrs) { |obj|
@@ -453,7 +452,6 @@ RSpec.describe Radius::Spec::ModelFactory do
       }.to change {
         block_initialized
       }.from(false)
-      # rubocop:enable Metrics/LineLength
       expect(block_initialized).to be an_instance
       expect(an_instance).to be_an_instance_of(AnyClass).and have_attributes(
         arg1: :custom,


### PR DESCRIPTION
This fixes the following warning:

    radius-spec/common_rubocop_rails.yml: Metrics/LineLength:IgnoredPatterns
    overrides the same parameter in common_rubocop.yml

Even updating the local `.rubocop.yml` file to use `common_rubocop_rails.yml` instead of `common_rubocop.yml` didn't produce the issue. Only when run from another project was this discovered 😩

I wonder if the failure to detect this has to do with the local repo containing the files directly while other projects include them via the gem. It would be good in the future to have some way to test the Rails setting integrations like this.