### PR TITLE
Rubocop updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ inherit_from: common_rubocop.yml
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Exclude:
+    - 'benchmarks/**/*'
     - 'lib/radius/spec/rspec.rb'
 
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Enhancements
 
-- TODO
+- Adjust common Rubocop configuration
+  - Customize `Style/AndOr` to flag only conditionals allowing `and` / `or` for
+    control flow
+  - Add `find` to functional method blocks
+  - Disable `Style/DoubleNegation` as this is a common Ruby idiom
+  - Disable `Style/StringLiteralsInInterpolation` to stay consistent with our
+    no preferences for single versus double quotes
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-- TODO
+- Remove `Include` from common Rubocop all cops configuration to fix issues
+  with Rubocop 0.56.0+ not seeing all expected files.
 
 
 ## 0.2.1 (May 17, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Breaking Change
 
-- Lock Rubocop to a minor release version in gemspec
+- Lock Rubocop to a minor release version in gemspec (Aaron Kromer, #5)
 
 ### Enhancements
 
-- Adjust common Rubocop configuration
+- Adjust common Rubocop configuration (Aaron Kromer, #5)
   - Customize `Style/AndOr` to flag only conditionals allowing `and` / `or` for
     control flow
   - Add `find` to functional method blocks
@@ -19,7 +19,7 @@
 ### Bug Fixes
 
 - Remove `Include` from common Rubocop all cops configuration to fix issues
-  with Rubocop 0.56.0+ not seeing all expected files.
+  with Rubocop 0.56.0+ not seeing all expected files. (Aaron Kromer, #5)
 
 
 ## 0.2.1 (May 17, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Full Changelog](https://github.com/RadiusNetworks/radius-spec/compare/v0.2.1...master)
 
+### Breaking Change
+
+- Lock Rubocop to a minor release version in gemspec
+
 ### Enhancements
 
 - Adjust common Rubocop configuration

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,13 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in radius-spec.gemspec
 gemspec
 
+group :benchmark, optional: true do
+  gem 'benchmark-ips', require: false
+  # TODO: See if this gem has an update in the future as it's gemspec is too
+  # strict and it was blocking other gems from installing / updating
+  gem 'kalibera', require: false, git: 'https://github.com/cupakromer/libkalibera.git'
+end
+
 group :debug do
   gem "pry-byebug", "~> 3.6", require: false
   gem "travis", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,6 @@ group :debug do
   gem "travis", require: false
 end
 
-group :development do
-  gem "rubocop", "~> 0.53", require: false
-end
-
 group :documentation do
   gem 'yard', '~> 0.9', require: false
 end

--- a/benchmarks/bm_setup.rb
+++ b/benchmarks/bm_setup.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'kalibera'
+require 'benchmark/ips'
+
+# Enable and start GC before each job run. Disable GC afterwards.
+#
+# Inspired by https://www.omniref.com/ruby/2.2.1/symbols/Benchmark/bm?#annotation=4095926&line=182
+class GCSuite
+  def warming(*)
+    run_gc
+  end
+
+  def running(*)
+    run_gc
+  end
+
+  def warmup_stats(*)
+  end
+
+  def add_report(*)
+  end
+
+private
+
+  def run_gc
+    GC.enable
+    GC.start
+    GC.disable
+  end
+end
+
+def as_boolean(val, default: nil)
+  case val.to_s.strip.downcase
+  when "true", "t", "yes", "y", "on", "1"
+    true
+  when "false", "f", "no", "n", "off", "0"
+    false
+  else
+    raise "Unknown boolean value #{val}" if default.nil?
+    default
+  end
+end
+
+def section(title = nil)
+  puts "\n#### #{title}" if title
+  puts "\n```"
+  GC.start
+  Benchmark.ips do |bench|
+    bench.config suite: GCSuite.new if GC_DISABLED
+    bench.config stats: :bootstrap, confidence: 95
+
+    yield bench
+    bench.compare!
+  end
+  puts "```"
+end
+
+def display_benchmark_header
+  puts
+  puts "### Environment"
+  puts
+  puts RUBY_DESCRIPTION
+  puts "GC Disabled: #{GC_DISABLED}"
+  puts
+  puts "### Test Cases"
+end
+
+GC_DISABLED = as_boolean(ENV['GC_DISABLED'], default: false)

--- a/benchmarks/call_vs_yield.rb
+++ b/benchmarks/call_vs_yield.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/call_vs_yield.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+# rubocop:disable Performance/RedundantBlockCall
+def block_call(&block)
+  block.call
+end
+
+def block_yield(&_block)
+  yield
+end
+
+def block_arg(&_block)
+  1 + 1 # Always do the same amount of work
+end
+
+def no_arg_yield
+  yield
+end
+
+def pass_through(&block)
+  no_arg_yield(&block)
+end
+
+section "Block call vs yield" do |bench|
+  bench.report("block.call") do |times|
+    i = 0
+    while i < times
+      block_call do
+        1 + 1
+      end
+      i += 1
+    end
+  end
+
+  bench.report("block yield") do |times|
+    i = 0
+    while i < times
+      block_yield do
+        1 + 1
+      end
+      i += 1
+    end
+  end
+
+  bench.report("block arg only") do |times|
+    i = 0
+    while i < times
+      block_arg do
+        1 + 1
+      end
+      i += 1
+    end
+  end
+
+  bench.report("no arg yield") do |times|
+    i = 0
+    while i < times
+      no_arg_yield do
+        1 + 1
+      end
+      i += 1
+    end
+  end
+
+  bench.report("pass through block") do |times|
+    i = 0
+    while i < times
+      pass_through do
+        1 + 1
+      end
+      i += 1
+    end
+  end
+end
+# rubocop:enable Performance/RedundantBlockCall
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Block call vs yield
+
+```
+Warming up --------------------------------------
+          block.call   117.672k i/100ms
+         block yield   272.613k i/100ms
+      block arg only   287.821k i/100ms
+        no arg yield   286.217k i/100ms
+  pass through block   251.757k i/100ms
+Calculating -------------------------------------
+          block.call      3.181M (± 0.9%) i/s -     15.886M in   5.010444s
+         block yield     14.017M (± 0.7%) i/s -     70.062M in   5.015163s
+      block arg only     17.835M (± 0.7%) i/s -     88.937M in   5.011243s
+        no arg yield     18.056M (± 0.6%) i/s -     90.158M in   5.010075s
+  pass through block     10.776M (± 0.8%) i/s -     53.876M in   5.019221s
+                   with 95.0% confidence
+
+Comparison:
+        no arg yield: 18056296.4 i/s
+      block arg only: 17835047.6 i/s - same-ish: difference falls within error
+         block yield: 14017426.6 i/s - 1.29x  (± 0.01) slower
+  pass through block: 10776151.4 i/s - 1.68x  (± 0.02) slower
+          block.call:  3180610.0 i/s - 5.68x  (± 0.06) slower
+                   with 95.0% confidence
+```
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: true
+
+### Test Cases
+
+#### Block call vs yield
+
+```
+Warming up --------------------------------------
+          block.call   134.623k i/100ms
+         block yield   276.955k i/100ms
+      block arg only   306.377k i/100ms
+        no arg yield   286.201k i/100ms
+  pass through block   259.025k i/100ms
+Calculating -------------------------------------
+          block.call      3.558M (± 2.6%) i/s -     17.097M in   5.033155s
+         block yield     14.469M (± 0.7%) i/s -     72.285M in   5.013029s
+      block arg only     18.173M (± 0.6%) i/s -     90.688M in   5.005679s
+        no arg yield     18.207M (± 0.6%) i/s -     90.726M in   5.001766s
+  pass through block     10.794M (± 0.8%) i/s -     53.877M in   5.010781s
+                   with 95.0% confidence
+
+Comparison:
+        no arg yield: 18206595.2 i/s
+      block arg only: 18172764.0 i/s - same-ish: difference falls within error
+         block yield: 14469142.9 i/s - 1.26x  (± 0.01) slower
+  pass through block: 10793657.6 i/s - 1.69x  (± 0.02) slower
+          block.call:  3557929.5 i/s - 5.12x  (± 0.14) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/case_equality_vs_class_check.rb
+++ b/benchmarks/case_equality_vs_class_check.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/case_equality_vs_class_check.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+section "Class match" do |bench|
+  x = "Any String"
+
+  bench.report("===") do
+    String === x # rubocop:disable Style/CaseEquality
+  end
+
+  bench.report("is_a?") do
+    x.is_a?(String)
+  end
+end
+
+section "Class NO match" do |bench|
+  x = :any_symbol
+
+  bench.report("===") do
+    String === x # rubocop:disable Style/CaseEquality
+  end
+
+  bench.report("is_a?") do
+    x.is_a?(String)
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: true
+
+### Test Cases
+
+#### Class match
+
+```
+Warming up --------------------------------------
+                 ===   284.703k i/100ms
+               is_a?   280.367k i/100ms
+Calculating -------------------------------------
+                 ===     11.394M (± 0.8%) i/s -     56.941M in   5.014392s
+               is_a?     11.068M (± 0.8%) i/s -     55.232M in   5.007549s
+                   with 95.0% confidence
+
+Comparison:
+                 ===: 11394313.8 i/s
+               is_a?: 11068062.4 i/s - 1.03x  (± 0.01) slower
+                   with 95.0% confidence
+```
+
+#### Class NO match
+
+```
+Warming up --------------------------------------
+                 ===   298.288k i/100ms
+               is_a?   290.294k i/100ms
+Calculating -------------------------------------
+                 ===     10.567M (± 0.7%) i/s -     52.797M in   5.007023s
+               is_a?     10.405M (± 0.7%) i/s -     51.963M in   5.006983s
+                   with 95.0% confidence
+
+Comparison:
+                 ===: 10567130.4 i/s
+               is_a?: 10405382.6 i/s - 1.02x  (± 0.01) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/cover_vs_include.rb
+++ b/benchmarks/cover_vs_include.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/cover_vs_include.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+INT_RANGE = (0..15)
+INT_VAR = 10
+
+section "Integer ranges" do |bench|
+  bench.report('range#cover?') do
+    INT_RANGE.cover?(INT_VAR)
+  end
+
+  bench.report('range#include?') do
+    INT_RANGE.include?(INT_VAR)
+  end
+
+  bench.report('range#member?') do
+    INT_RANGE.member?(INT_VAR)
+  end
+
+  bench.report('plain compare') do
+    0 < INT_VAR && INT_VAR < 15
+  end
+end
+
+BEGIN_OF_JULY = Time.utc(2015, 7, 1)
+END_OF_JULY = Time.utc(2015, 7, 31)
+DAY_IN_JULY = Time.utc(2015, 7, 15)
+
+TIME_RANGE = (BEGIN_OF_JULY..END_OF_JULY)
+
+section "Time ranges" do |bench|
+  bench.report('range#cover?') do
+    TIME_RANGE.cover?(DAY_IN_JULY)
+  end
+
+  bench.report('range#include?') do
+    TIME_RANGE.include?(DAY_IN_JULY)
+  end
+
+  bench.report('range#member?') do
+    TIME_RANGE.member?(DAY_IN_JULY)
+  end
+
+  bench.report('plain compare') do
+    BEGIN_OF_JULY < DAY_IN_JULY && DAY_IN_JULY < END_OF_JULY
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Integer ranges
+
+```
+Warming up --------------------------------------
+        range#cover?   247.959k i/100ms
+      range#include?   251.846k i/100ms
+       range#member?   251.416k i/100ms
+       plain compare   305.858k i/100ms
+Calculating -------------------------------------
+        range#cover?      6.400M (± 0.8%) i/s -     31.987M in   5.008881s
+      range#include?      6.328M (± 0.8%) i/s -     31.733M in   5.025377s
+       range#member?      6.366M (± 0.6%) i/s -     31.930M in   5.022146s
+       plain compare     11.042M (± 0.8%) i/s -     55.054M in   4.999666s
+                   with 95.0% confidence
+
+Comparison:
+       plain compare: 11041684.3 i/s
+        range#cover?:  6399832.9 i/s - 1.73x  (± 0.02) slower
+       range#member?:  6366323.6 i/s - 1.73x  (± 0.02) slower
+      range#include?:  6327682.0 i/s - 1.75x  (± 0.02) slower
+                   with 95.0% confidence
+```
+
+#### Time ranges
+
+```
+Warming up --------------------------------------
+        range#cover?   249.380k i/100ms
+      range#include?   247.775k i/100ms
+       range#member?   247.446k i/100ms
+       plain compare   223.517k i/100ms
+Calculating -------------------------------------
+        range#cover?      5.942M (± 0.7%) i/s -     29.676M in   5.002164s
+      range#include?      5.724M (± 0.7%) i/s -     28.742M in   5.028509s
+       range#member?      5.771M (± 0.7%) i/s -     28.951M in   5.024809s
+       plain compare      4.751M (± 0.9%) i/s -     23.916M in   5.046978s
+                   with 95.0% confidence
+
+Comparison:
+        range#cover?:  5941582.8 i/s
+       range#member?:  5770708.7 i/s - 1.03x  (± 0.01) slower
+      range#include?:  5723795.5 i/s - 1.04x  (± 0.01) slower
+       plain compare:  4750545.5 i/s - 1.25x  (± 0.01) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/delete_vs_tr.rb
+++ b/benchmarks/delete_vs_tr.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/delete_vs_tr.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+[
+  ["No Removal",         "Any String Chars", "m",   ""],
+  ["Single Removal",     "Any String Chars", "i",   ""],
+  ["Multiple Removal",   "Any String Chars", "n",   ""],
+  ["Multi-Char Removal", "Any String Chars", "nar", ""],
+].each do |title, str, pattern, replacement|
+  section title do |bench|
+    bench.report("delete") do
+      str.delete(pattern)
+    end
+
+    bench.report("tr") do
+      str.tr(pattern, replacement)
+    end
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### No Removal
+
+```
+Warming up --------------------------------------
+              delete   164.989k i/100ms
+                  tr   163.504k i/100ms
+Calculating -------------------------------------
+              delete      2.578M (± 0.9%) i/s -     13.034M in   5.065099s
+                  tr      2.566M (± 0.8%) i/s -     12.917M in   5.039546s
+                   with 95.0% confidence
+
+Comparison:
+              delete:  2578043.5 i/s
+                  tr:  2565794.9 i/s - same-ish: difference falls within error
+                   with 95.0% confidence
+```
+
+#### Single Removal
+
+```
+Warming up --------------------------------------
+              delete   169.321k i/100ms
+                  tr   173.594k i/100ms
+Calculating -------------------------------------
+              delete      2.779M (± 1.1%) i/s -     13.884M in   5.010559s
+                  tr      2.721M (± 1.0%) i/s -     13.714M in   5.050566s
+                   with 95.0% confidence
+
+Comparison:
+              delete:  2778762.2 i/s
+                  tr:  2721121.1 i/s - 1.02x  (± 0.02) slower
+                   with 95.0% confidence
+```
+
+#### Multiple Removal
+
+```
+Warming up --------------------------------------
+              delete   173.074k i/100ms
+                  tr   171.824k i/100ms
+Calculating -------------------------------------
+              delete      2.804M (± 1.0%) i/s -     14.019M in   5.009616s
+                  tr      2.739M (± 1.0%) i/s -     13.746M in   5.030533s
+                   with 95.0% confidence
+
+Comparison:
+              delete:  2804348.9 i/s
+                  tr:  2739399.1 i/s - 1.02x  (± 0.01) slower
+                   with 95.0% confidence
+```
+
+#### Multi-Char Removal
+
+```
+Warming up --------------------------------------
+              delete   165.485k i/100ms
+                  tr   158.961k i/100ms
+Calculating -------------------------------------
+              delete      2.547M (± 1.3%) i/s -     12.742M in   5.019971s
+                  tr      2.507M (± 1.0%) i/s -     12.558M in   5.018688s
+                   with 95.0% confidence
+
+Comparison:
+              delete:  2547442.6 i/s
+                  tr:  2507427.2 i/s - same-ish: difference falls within error
+                   with 95.0% confidence
+```

--- a/benchmarks/double_negation.rb
+++ b/benchmarks/double_negation.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/double_negation.rb
+require_relative 'bm_setup'
+require 'active_support'
+require 'active_support/core_ext/object/blank'
+
+display_benchmark_header
+
+# rubocop:disable Style/NonNilCheck
+# As this is basically a micro-benchmark we use the block with `while` idiom
+[nil, [], Object.new].each do |x|
+  section x.inspect do |bench|
+    bench.report("!!") do |times|
+      i = 0
+      while i < times
+        !!x
+        i += 1
+      end
+    end
+
+    bench.report("!nil?") do |times|
+      i = 0
+      while i < times
+        !x.nil?
+        i += 1
+      end
+    end
+
+    bench.report("nil !=") do |times|
+      i = 0
+      while i < times
+        nil != x
+        i += 1
+      end
+    end
+
+    bench.report("present?") do |times|
+      i = 0
+      while i < times
+        x.present?
+        i += 1
+      end
+    end
+  end
+end
+
+# When performing the initial testing we used `x == nil`. However, that was
+# shockingly slow for the empty array case. Because of that we inverted the
+# conditional in the above condition. However, as proof of this oddity and to
+# allow us to track behavior in future versions we include this additional
+# benchmark showing the issue.
+section "Empty array `nil` comparison" do |bench|
+  x = []
+
+  bench.report("!= nil") do |times|
+    i = 0
+    while i < times
+      nil != x
+      i += 1
+    end
+  end
+
+  bench.report("nil !=") do |times|
+    i = 0
+    while i < times
+      x != nil
+      i += 1
+    end
+  end
+end
+# rubocop:enable Style/NonNilCheck
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: true
+
+### Test Cases
+
+#### nil
+
+```
+Warming up --------------------------------------
+                  !!   320.852k i/100ms
+               !nil?   313.833k i/100ms
+              nil !=   330.298k i/100ms
+            present?   294.813k i/100ms
+Calculating -------------------------------------
+                  !!     41.841M (± 0.6%) i/s -    207.591M in   5.000435s
+               !nil?     30.851M (± 0.7%) i/s -    153.464M in   5.005301s
+              nil !=     38.424M (± 0.5%) i/s -    191.573M in   5.007580s
+            present?     19.660M (± 0.7%) i/s -     97.878M in   4.999761s
+                   with 95.0% confidence
+
+Comparison:
+                  !!: 41841263.8 i/s
+              nil !=: 38424408.4 i/s - 1.09x  (± 0.01) slower
+               !nil?: 30850983.5 i/s - 1.36x  (± 0.01) slower
+            present?: 19660459.4 i/s - 2.13x  (± 0.02) slower
+                   with 95.0% confidence
+```
+
+#### []
+
+```
+Warming up --------------------------------------
+                  !!   317.562k i/100ms
+               !nil?   311.181k i/100ms
+              nil !=   319.266k i/100ms
+            present?   293.159k i/100ms
+Calculating -------------------------------------
+                  !!     42.487M (± 0.6%) i/s -    211.179M in   5.005333s
+               !nil?     31.078M (± 0.5%) i/s -    154.968M in   5.005557s
+              nil !=     38.313M (± 0.6%) i/s -    190.283M in   5.000799s
+            present?     21.854M (± 0.7%) i/s -    108.762M in   5.002198s
+                   with 95.0% confidence
+
+Comparison:
+                  !!: 42487427.1 i/s
+              nil !=: 38312618.0 i/s - 1.11x  (± 0.01) slower
+               !nil?: 31078123.9 i/s - 1.37x  (± 0.01) slower
+            present?: 21854143.8 i/s - 1.94x  (± 0.02) slower
+                   with 95.0% confidence
+```
+
+#### #<Object:0x00007f9c0a968310>
+
+```
+Warming up --------------------------------------
+                  !!   328.432k i/100ms
+               !nil?   307.084k i/100ms
+              nil !=   324.749k i/100ms
+            present?   261.758k i/100ms
+Calculating -------------------------------------
+                  !!     40.897M (± 0.5%) i/s -    203.628M in   5.005426s
+               !nil?     30.242M (± 0.6%) i/s -    150.471M in   5.000563s
+              nil !=     39.610M (± 0.6%) i/s -    197.123M in   5.005610s
+            present?     12.163M (± 0.8%) i/s -     60.728M in   5.011771s
+                   with 95.0% confidence
+
+Comparison:
+                  !!: 40897495.2 i/s
+              nil !=: 39610078.3 i/s - 1.03x  (± 0.01) slower
+               !nil?: 30242403.1 i/s - 1.35x  (± 0.01) slower
+            present?: 12162705.7 i/s - 3.36x  (± 0.03) slower
+                   with 95.0% confidence
+```
+
+#### Empty array `nil` comparison
+
+```
+Warming up --------------------------------------
+              != nil   326.024k i/100ms
+              nil !=   270.805k i/100ms
+Calculating -------------------------------------
+              != nil     40.133M (± 0.5%) i/s -    199.853M in   5.004102s
+              nil !=     11.551M (± 0.9%) i/s -     57.681M in   5.020992s
+                   with 95.0% confidence
+
+Comparison:
+              != nil: 40133046.7 i/s
+              nil !=: 11551012.8 i/s - 3.47x  (± 0.04) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/empty_literal.rb
+++ b/benchmarks/empty_literal.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/empty_literal.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+# rubocop:disable Style/EmptyLiteral
+section "[] vs Array.new" do |bench|
+  bench.report("Array.new") do
+    Array.new
+    nil
+  end
+
+  bench.report("[]") do
+    []
+    nil
+  end
+end
+
+section "{} vs Hash.new" do |bench|
+  bench.report("Hash.new") do
+    Hash.new
+    nil
+  end
+
+  bench.report("{}") do
+    {}
+    nil
+  end
+end
+# rubocop:enable Style/EmptyLiteral
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### [] vs Array.new
+
+```
+Warming up --------------------------------------
+           Array.new   238.371k i/100ms
+                  []   336.249k i/100ms
+Calculating -------------------------------------
+           Array.new      6.298M (± 1.0%) i/s -     31.465M in   5.014660s
+                  []     14.157M (± 0.8%) i/s -     70.612M in   5.004166s
+                   with 95.0% confidence
+
+Comparison:
+                  []: 14157286.9 i/s
+           Array.new:  6297668.8 i/s - 2.25x  (± 0.03) slower
+                   with 95.0% confidence
+```
+
+#### {} vs Hash.new
+
+```
+Warming up --------------------------------------
+            Hash.new   140.548k i/100ms
+                  {}   348.340k i/100ms
+Calculating -------------------------------------
+            Hash.new      2.203M (± 1.1%) i/s -     11.103M in   5.056212s
+                  {}     14.285M (± 0.6%) i/s -     71.410M in   5.010915s
+                   with 95.0% confidence
+
+Comparison:
+                  {}: 14285184.2 i/s
+            Hash.new:  2202622.4 i/s - 6.49x  (± 0.08) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/format_string.rb
+++ b/benchmarks/format_string.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/format_string.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+SINGLE_TOKEN_HASH = { greeting: 'Hello' }.freeze
+MULTI_TOKEN_HASH = {
+  greeting: 'Hello',
+  name: 'Benchmark',
+  message: 'Always a good idea to benchmark',
+}.freeze
+
+# rubocop:disable Style/FormatString
+section "Format String" do |bench|
+  bench.report("String#%") do
+    '%10s' % 'hoge'
+  end
+
+  bench.report("format") do
+    format '%10s', 'hoge'
+  end
+
+  bench.report("sprintf") do
+    sprintf '%10s', 'hoge'
+  end
+end
+# rubocop:enable Style/FormatString
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Format String
+
+```
+Warming up --------------------------------------
+            String#%   148.922k i/100ms
+              format   162.561k i/100ms
+             sprintf   157.745k i/100ms
+Calculating -------------------------------------
+            String#%      2.363M (± 0.8%) i/s -     11.914M in   5.049141s
+              format      2.668M (± 0.8%) i/s -     13.330M in   5.002105s
+             sprintf      2.609M (± 0.8%) i/s -     13.093M in   5.025561s
+                   with 95.0% confidence
+
+Comparison:
+              format:  2668054.9 i/s
+             sprintf:  2609234.8 i/s - 1.02x  (± 0.01) slower
+            String#%:  2363040.2 i/s - 1.13x  (± 0.01) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/format_string_token.rb
+++ b/benchmarks/format_string_token.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/format_string_token.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+SINGLE_TOKEN_HASH = { greeting: 'Hello' }.freeze
+MULTI_TOKEN_HASH = {
+  greeting: 'Hello',
+  name: 'Benchmark',
+  message: 'Always a good idea to benchmark',
+}.freeze
+
+# rubocop:disable Style/FormatStringToken
+section "Format String Token (single token - inline token hash)" do |bench|
+  bench.report("annotated") do
+    format '%<greeting>s', greeting: 'Hello'
+  end
+
+  bench.report("template") do
+    format '%{greeting}', greeting: 'Hello'
+  end
+
+  bench.report("unannotated") do
+    format '%s', 'Hello'
+  end
+end
+
+section "Format String Token (single token - constant token hash)" do |bench|
+  bench.report("annotated") do
+    format '%<greeting>s', SINGLE_TOKEN_HASH
+  end
+
+  bench.report("template") do
+    format '%{greeting}', SINGLE_TOKEN_HASH
+  end
+
+  bench.report("unannotated") do
+    format '%s', 'Hello'
+  end
+end
+
+section "Format String Token (multiple tokens - constant token hash)" do |bench|
+  bench.report("annotated") do
+    format '%<greeting>s %<name>s, %<message>s!', MULTI_TOKEN_HASH
+  end
+
+  bench.report("template") do
+    format '%{greeting} %{name}, %{message}!', MULTI_TOKEN_HASH
+  end
+
+  bench.report("unannotated") do
+    format '%s %s, %s', 'Hello', 'Benchmark!', 'Always a good idea to benchmark'
+  end
+end
+# rubocop:enable Style/FormatStringToken
+
+section "Format String Token (annotated)" do |bench|
+  bench.report("inline hash") do
+    format '%<greeting>s', greeting: 'Hello'
+  end
+
+  bench.report("constant hash") do
+    format '%<greeting>s', SINGLE_TOKEN_HASH
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Format String Token (single token - inline token hash)
+
+```
+Warming up --------------------------------------
+           annotated    88.435k i/100ms
+            template    87.693k i/100ms
+         unannotated   173.134k i/100ms
+Calculating -------------------------------------
+           annotated      1.160M (± 1.3%) i/s -      5.837M in   5.044452s
+            template      1.188M (± 1.2%) i/s -      5.963M in   5.031961s
+         unannotated      3.053M (± 0.8%) i/s -     15.409M in   5.055505s
+                   with 95.0% confidence
+
+Comparison:
+         unannotated:  3053228.5 i/s
+            template:  1187997.4 i/s - 2.57x  (± 0.04) slower
+           annotated:  1160462.9 i/s - 2.63x  (± 0.04) slower
+                   with 95.0% confidence
+```
+
+#### Format String Token (single token - constant token hash)
+
+```
+Warming up --------------------------------------
+           annotated   142.944k i/100ms
+            template   142.146k i/100ms
+         unannotated   178.653k i/100ms
+Calculating -------------------------------------
+           annotated      2.155M (± 0.8%) i/s -     10.864M in   5.048122s
+            template      2.158M (± 1.0%) i/s -     10.803M in   5.016911s
+         unannotated      3.081M (± 0.8%) i/s -     15.543M in   5.053055s
+                   with 95.0% confidence
+
+Comparison:
+         unannotated:  3080897.8 i/s
+            template:  2157563.3 i/s - 1.43x  (± 0.02) slower
+           annotated:  2155420.1 i/s - 1.43x  (± 0.02) slower
+                   with 95.0% confidence
+```
+
+#### Format String Token (multiple tokens - constant token hash)
+
+```
+Warming up --------------------------------------
+           annotated    69.462k i/100ms
+            template    59.389k i/100ms
+         unannotated    57.845k i/100ms
+Calculating -------------------------------------
+           annotated    890.828k (± 3.4%) i/s -      4.307M in   5.042996s
+            template    885.637k (± 2.8%) i/s -      4.276M in   5.017872s
+         unannotated      1.343M (± 3.8%) i/s -      6.189M in   5.104055s
+                   with 95.0% confidence
+
+Comparison:
+         unannotated:  1342803.3 i/s
+           annotated:   890828.1 i/s - 1.51x  (± 0.08) slower
+            template:   885637.5 i/s - 1.52x  (± 0.07) slower
+                   with 95.0% confidence
+```
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Format String Token (annotated)
+
+```
+Warming up --------------------------------------
+         inline hash    91.059k i/100ms
+       constant hash   135.572k i/100ms
+Calculating -------------------------------------
+         inline hash      1.218M (± 1.2%) i/s -      6.101M in   5.024187s
+       constant hash      2.135M (± 1.0%) i/s -     10.710M in   5.028115s
+                   with 95.0% confidence
+
+Comparison:
+       constant hash:  2135050.5 i/s
+         inline hash:  1217810.2 i/s - 1.75x  (± 0.03) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/gsub_vs_tr.rb
+++ b/benchmarks/gsub_vs_tr.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/gsub_vs_tr.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+[
+  ["No Replacement",       "Any String", "m", /m/, "-"],
+  ["Single Replacement",   "Any String", "i", /i/, "-"],
+  ["Multiple Replacement", "Any String", "n", /n/, "-"],
+].each do |title, str, pattern, regexp, replacement|
+  section title do |bench|
+    bench.report("gsub(string)") do
+      str.gsub(pattern, replacement)
+    end
+
+    bench.report("gsub(regexp)") do
+      str.gsub(regexp, replacement)
+    end
+
+    bench.report("tr") do
+      str.tr(pattern, replacement)
+    end
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### No Replacement
+
+```
+Warming up --------------------------------------
+        gsub(string)   225.903k i/100ms
+        gsub(regexp)   150.469k i/100ms
+                  tr   225.874k i/100ms
+Calculating -------------------------------------
+        gsub(string)      4.848M (± 0.7%) i/s -     24.398M in   5.042073s
+        gsub(regexp)      2.558M (± 1.3%) i/s -     12.790M in   5.018370s
+                  tr      4.872M (± 1.0%) i/s -     24.394M in   5.020983s
+                   with 95.0% confidence
+
+Comparison:
+                  tr:  4872264.7 i/s
+        gsub(string):  4847903.4 i/s - same-ish: difference falls within error
+        gsub(regexp):  2557821.1 i/s - 1.91x  (± 0.03) slower
+                   with 95.0% confidence
+```
+
+#### Single Replacement
+
+```
+Warming up --------------------------------------
+        gsub(string)   115.202k i/100ms
+        gsub(regexp)    64.609k i/100ms
+                  tr   230.643k i/100ms
+Calculating -------------------------------------
+        gsub(string)      1.431M (± 1.6%) i/s -      7.143M in   5.010792s
+        gsub(regexp)    663.965k (± 1.0%) i/s -      3.360M in   5.067248s
+                  tr      4.517M (± 0.9%) i/s -     22.603M in   5.014505s
+                   with 95.0% confidence
+
+Comparison:
+                  tr:  4516906.0 i/s
+        gsub(string):  1430926.3 i/s - 3.16x  (± 0.06) slower
+        gsub(regexp):   663964.7 i/s - 6.80x  (± 0.09) slower
+                   with 95.0% confidence
+```
+
+#### Multiple Replacement
+
+```
+Warming up --------------------------------------
+        gsub(string)    92.833k i/100ms
+        gsub(regexp)    51.482k i/100ms
+                  tr   222.779k i/100ms
+Calculating -------------------------------------
+        gsub(string)      1.263M (± 1.3%) i/s -      6.313M in   5.014495s
+        gsub(regexp)    663.557k (± 1.4%) i/s -      3.346M in   5.061408s
+                  tr      4.786M (± 0.9%) i/s -     24.060M in   5.040074s
+                   with 95.0% confidence
+
+Comparison:
+                  tr:  4785813.8 i/s
+        gsub(string):  1262609.0 i/s - 3.79x  (± 0.06) slower
+        gsub(regexp):   663557.0 i/s - 7.21x  (± 0.12) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/hash_merge.rb
+++ b/benchmarks/hash_merge.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/hash_merge.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+ENUM = (1..100)
+
+def hash_merge
+  tmp = {}
+  ENUM.each do |e|
+    tmp.merge! e => e
+  end
+  tmp
+end
+
+def hash_assign
+  tmp = {}
+  ENUM.each do |e|
+    tmp[e] = e
+  end
+  tmp
+end
+
+COMPOSE = {
+  a: 'a',
+  b: 'b',
+  c: 'c',
+}.freeze
+
+def hash_compose_merge
+  { one: 1 }.merge(COMPOSE)
+end
+
+def hash_compose_merge!
+  { one: 1 }.merge!(COMPOSE)
+end
+
+def hash_compose_splat
+  { one: 1, **COMPOSE }
+end
+
+section "Hash merge vs assign" do |bench|
+  bench.report("Hash#merge!") do
+    hash_merge
+  end
+
+  bench.report("Hash#[]=") do
+    hash_assign
+  end
+end
+
+section "Hash compose: merge vs splat" do |bench|
+  bench.report("merge") do
+    hash_compose_merge
+  end
+
+  bench.report("merge!") do
+    hash_compose_merge!
+  end
+
+  bench.report("splat") do
+    hash_compose_splat
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Hash merge vs assign
+
+```
+Warming up --------------------------------------
+         Hash#merge!     1.760k i/100ms
+            Hash#[]=     7.821k i/100ms
+Calculating -------------------------------------
+         Hash#merge!     17.746k (± 1.1%) i/s -     89.760k in   5.065762s
+            Hash#[]=     83.691k (± 1.2%) i/s -    422.334k in   5.057697s
+                   with 95.0% confidence
+
+Comparison:
+            Hash#[]=:    83691.2 i/s
+         Hash#merge!:    17746.3 i/s - 4.71x  (± 0.08) slower
+                   with 95.0% confidence
+```
+
+#### Hash compose: merge vs splat
+
+```
+Warming up --------------------------------------
+               merge    78.448k i/100ms
+              merge!   111.435k i/100ms
+               splat   111.927k i/100ms
+Calculating -------------------------------------
+               merge    978.337k (± 1.0%) i/s -      4.942M in   5.061428s
+              merge!      1.571M (± 1.0%) i/s -      7.912M in   5.046875s
+               splat      1.587M (± 1.0%) i/s -      7.947M in   5.017037s
+                   with 95.0% confidence
+
+Comparison:
+               splat:  1587073.4 i/s
+              merge!:  1570636.9 i/s - same-ish: difference falls within error
+               merge:   978337.3 i/s - 1.62x  (± 0.02) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/kwargs.rb
+++ b/benchmarks/kwargs.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/kwargs.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+NAME = "any name"
+STATIC_OPTS = { name: "any name" }.freeze
+
+def hash_param(hash)
+  hash
+end
+
+def kwarg_param(name: nil)
+  name
+end
+
+def kwarg_splat_param(**kwargs)
+  kwargs
+end
+
+def static_opts
+  kwarg_param STATIC_OPTS
+end
+
+def named_opts
+  kwarg_param name: NAME
+end
+
+def splat_opts
+  kwarg_splat_param name: NAME
+end
+
+def hash_opts
+  hash_param name: NAME
+end
+
+section "kwargs vs hash method" do |x|
+  x.report("hash param") do
+    hash_opts
+  end
+
+  x.report("kwarg param") do
+    named_opts
+  end
+
+  x.report("kwarg splat param") do
+    splat_opts
+  end
+
+  x.compare!
+end
+
+section "Call kwargs method" do |x|
+  x.report("static opts") do
+    static_opts
+  end
+
+  x.report("named opts") do
+    named_opts
+  end
+
+  x.compare!
+end
+
+__END__
+
+Perhaps surprisingly the kwarg parameters option is much faster. I'm not sure
+why this actually is, but my guess is that Ruby optimizes this during the byte
+code process.
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### kwargs vs hash method
+
+```
+Warming up --------------------------------------
+          hash param   131.753k i/100ms
+         kwarg param   266.657k i/100ms
+   kwarg splat param    66.641k i/100ms
+Calculating -------------------------------------
+          hash param      2.057M (± 1.6%) i/s -     10.277M in   5.023252s
+         kwarg param      7.351M (± 0.7%) i/s -     36.799M in   5.015356s
+   kwarg splat param    850.179k (± 1.4%) i/s -      4.265M in   5.035194s
+                   with 95.0% confidence
+
+Comparison:
+         kwarg param:  7351007.8 i/s
+          hash param:  2056501.2 i/s - 3.57x  (± 0.06) slower
+   kwarg splat param:   850179.4 i/s - 8.64x  (± 0.13) slower
+                   with 95.0% confidence
+```
+
+#### Call kwargs method
+
+```
+Warming up --------------------------------------
+         static opts   127.699k i/100ms
+          named opts   274.978k i/100ms
+Calculating -------------------------------------
+         static opts      1.879M (± 1.0%) i/s -      9.450M in   5.039627s
+          named opts      6.938M (± 1.1%) i/s -     34.647M in   5.014500s
+                   with 95.0% confidence
+
+Comparison:
+          named opts:  6937888.3 i/s
+         static opts:  1878705.6 i/s - 3.69x  (± 0.05) slower
+                   with 95.0% confidence
+```
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: true
+
+### Test Cases
+
+#### kwargs vs hash method
+
+```
+Warming up --------------------------------------
+          hash param   144.722k i/100ms
+         kwarg param   266.216k i/100ms
+   kwarg splat param    67.212k i/100ms
+Calculating -------------------------------------
+          hash param      2.318M (± 5.2%) i/s -     10.709M in   5.017846s
+         kwarg param      7.381M (± 0.8%) i/s -     37.004M in   5.026198s
+   kwarg splat param    893.963k (±15.1%) i/s -      3.159M in   5.180853s
+                   with 95.0% confidence
+
+Comparison:
+         kwarg param:  7380700.1 i/s
+          hash param:  2317626.6 i/s - 3.19x  (± 0.17) slower
+   kwarg splat param:   893963.2 i/s - 8.26x  (± 1.26) slower
+                   with 95.0% confidence
+```
+
+#### Call kwargs method
+
+```
+Warming up --------------------------------------
+         static opts   157.568k i/100ms
+          named opts   271.741k i/100ms
+Calculating -------------------------------------
+         static opts      1.741M (±12.7%) i/s -      7.091M in   5.038616s
+          named opts      7.335M (± 0.7%) i/s -     36.685M in   5.010800s
+                   with 95.0% confidence
+
+Comparison:
+          named opts:  7335402.3 i/s
+         static opts:  1740760.5 i/s - 4.21x  (± 0.53) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/max_ternary.rb
+++ b/benchmarks/max_ternary.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/max_ternary.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+section "Min First" do |bench|
+  x = 1
+  y = 2
+
+  bench.report("max") do
+    [x, y].max
+  end
+
+  bench.report("ternary") do
+    (x < y) ? y : x
+  end
+end
+
+section "Max First" do |bench|
+  x = 2
+  y = 1
+
+  bench.report("max") do
+    [x, y].max
+  end
+
+  bench.report("ternary") do
+    (x < y) ? y : x
+  end
+end
+
+section "Equal values" do
+  x = 2
+  y = 2
+
+  bench.report("max") do
+    [x, y].max
+  end
+
+  bench.report("ternary") do
+    (x < y) ? y : x
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Min First
+
+```
+Warming up --------------------------------------
+                 max   349.454k i/100ms
+             ternary   349.128k i/100ms
+Calculating -------------------------------------
+                 max     12.628M (± 0.9%) i/s -     62.902M in   5.000232s
+             ternary     12.853M (± 0.8%) i/s -     64.240M in   5.015540s
+                   with 95.0% confidence
+
+Comparison:
+             ternary: 12852607.6 i/s
+                 max: 12628052.1 i/s - 1.02x  (± 0.01) slower
+                   with 95.0% confidence
+```
+
+#### Max First
+
+```
+Warming up --------------------------------------
+                 max   346.104k i/100ms
+             ternary   344.003k i/100ms
+Calculating -------------------------------------
+                 max     12.788M (± 0.7%) i/s -     64.029M in   5.022073s
+             ternary     12.607M (± 0.7%) i/s -     62.953M in   5.006764s
+                   with 95.0% confidence
+
+Comparison:
+                 max: 12787891.5 i/s
+             ternary: 12606659.1 i/s - same-ish: difference falls within error
+                   with 95.0% confidence
+```
+
+#### Equal values
+
+```
+Warming up --------------------------------------
+                 max   340.468k i/100ms
+             ternary   343.788k i/100ms
+Calculating -------------------------------------
+                 max     12.278M (± 0.9%) i/s -     61.284M in   5.010572s
+             ternary     12.703M (± 0.9%) i/s -     63.601M in   5.026552s
+                   with 95.0% confidence
+
+Comparison:
+             ternary: 12702775.1 i/s
+                 max: 12277915.1 i/s - 1.03x  (± 0.01) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/max_ternary_micro.rb
+++ b/benchmarks/max_ternary_micro.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/max_ternary_micro.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+section "Min First" do |bench|
+  x = 1
+  y = 2
+
+  bench.report("max") do |times|
+    i = 0
+    while i < times
+      [x, y].max
+      i += 1
+    end
+  end
+
+  bench.report("ternary") do |times|
+    i = 0
+    while i < times
+      (x < y) ? y : x
+      i += 1
+    end
+  end
+end
+
+section "Max First" do |bench|
+  x = 2
+  y = 1
+
+  bench.report("max") do |times|
+    i = 0
+    while i < times
+      [x, y].max
+      i += 1
+    end
+  end
+
+  bench.report("ternary") do |times|
+    i = 0
+    while i < times
+      (x < y) ? y : x
+      i += 1
+    end
+  end
+end
+
+section "Equal values" do |bench|
+  x = 2
+  y = 2
+
+  bench.report("max") do |times|
+    i = 0
+    while i < times
+      [x, y].max
+      i += 1
+    end
+  end
+
+  bench.report("ternary") do |times|
+    i = 0
+    while i < times
+      (x < y) ? y : x
+      i += 1
+    end
+  end
+end
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Min First
+
+```
+Warming up --------------------------------------
+                 max   318.262k i/100ms
+             ternary   330.711k i/100ms
+Calculating -------------------------------------
+                 max     38.997M (± 0.6%) i/s -    193.822M in   5.001947s
+             ternary     48.280M (± 0.5%) i/s -    240.096M in   5.002313s
+                   with 95.0% confidence
+
+Comparison:
+             ternary: 48279773.6 i/s
+                 max: 38996762.1 i/s - 1.24x  (± 0.01) slower
+                   with 95.0% confidence
+```
+
+#### Max First
+
+```
+Warming up --------------------------------------
+                 max   336.333k i/100ms
+             ternary   344.267k i/100ms
+Calculating -------------------------------------
+                 max     38.699M (± 0.7%) i/s -    192.046M in   5.000931s
+             ternary     50.601M (± 0.6%) i/s -    251.315M in   5.002150s
+                   with 95.0% confidence
+
+Comparison:
+             ternary: 50601023.9 i/s
+                 max: 38699482.7 i/s - 1.31x  (± 0.01) slower
+                   with 95.0% confidence
+```
+
+#### Equal values
+
+```
+Warming up --------------------------------------
+                 max   331.543k i/100ms
+             ternary   342.686k i/100ms
+Calculating -------------------------------------
+                 max     39.661M (± 0.6%) i/s -    197.268M in   5.004271s
+             ternary     47.147M (± 0.5%) i/s -    234.740M in   5.006089s
+                   with 95.0% confidence
+
+Comparison:
+             ternary: 47147208.6 i/s
+                 max: 39660659.9 i/s - 1.19x  (± 0.01) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/unfreeze_string.rb
+++ b/benchmarks/unfreeze_string.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/unfreeze_string.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+# rubocop:disable Performance/UnfreezeString
+section "Unfreezing empty string" do |bench|
+  bench.report("String.new") do
+    String.new
+  end
+
+  bench.report("+") do
+    +""
+  end
+
+  bench.report("dup") do
+    "".dup
+  end
+end
+
+STRING = "Any String"
+section "Unfreezing string" do |bench|
+  bench.report("String.new") do
+    String.new(STRING)
+  end
+
+  bench.report("+") do
+    +STRING
+  end
+
+  bench.report("dup") do
+    STRING.dup
+  end
+end
+# rubocop:enable Performance/UnfreezeString
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Unfreezing empty string
+
+```
+Warming up --------------------------------------
+          String.new   262.027k i/100ms
+                   +   286.997k i/100ms
+                 dup   217.963k i/100ms
+Calculating -------------------------------------
+          String.new      6.791M (± 0.9%) i/s -     34.064M in   5.029927s
+                   +      8.811M (± 1.1%) i/s -     43.911M in   5.011455s
+                 dup      4.627M (± 1.0%) i/s -     23.104M in   5.007394s
+                   with 95.0% confidence
+
+Comparison:
+                   +:  8810714.9 i/s
+          String.new:  6791074.6 i/s - 1.30x  (± 0.02) slower
+                 dup:  4626875.0 i/s - 1.90x  (± 0.03) slower
+                   with 95.0% confidence
+```
+
+#### Unfreezing string
+
+```
+Warming up --------------------------------------
+          String.new   220.258k i/100ms
+                   +   287.795k i/100ms
+                 dup   214.192k i/100ms
+Calculating -------------------------------------
+          String.new      4.624M (± 0.8%) i/s -     23.127M in   5.010887s
+                   +      8.946M (± 0.9%) i/s -     44.608M in   5.001680s
+                 dup      4.513M (± 0.9%) i/s -     22.704M in   5.041383s
+                   with 95.0% confidence
+
+Comparison:
+                   +:  8946340.5 i/s
+          String.new:  4624267.9 i/s - 1.93x  (± 0.02) slower
+                 dup:  4513230.8 i/s - 1.98x  (± 0.02) slower
+                   with 95.0% confidence
+```

--- a/benchmarks/unpack_first.rb
+++ b/benchmarks/unpack_first.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Run from the command line: bundle exec ruby benchmarks/unpack_first.rb
+require_relative 'bm_setup'
+
+display_benchmark_header
+
+PACKED_STRING = "foo"
+PACKED_FORMAT = "h*"
+
+# rubocop:disable Style/UnpackFirst
+section "Unpacking strings" do |bench|
+  bench.report("unpack.first") do
+    PACKED_STRING.unpack(PACKED_FORMAT).first
+  end
+
+  bench.report("unpack[0]") do
+    PACKED_STRING.unpack(PACKED_FORMAT)[0]
+  end
+
+  bench.report("unpack1") do
+    PACKED_STRING.unpack1(PACKED_FORMAT)
+  end
+end
+# rubocop:enable Style/UnpackFirst
+
+__END__
+
+### Environment
+
+ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin16]
+GC Disabled: false
+
+### Test Cases
+
+#### Unpacking strings
+
+```
+Warming up --------------------------------------
+        unpack.first   228.848k i/100ms
+           unpack[0]   225.375k i/100ms
+             unpack1   254.431k i/100ms
+Calculating -------------------------------------
+        unpack.first      5.074M (± 1.0%) i/s -     25.402M in   5.021645s
+           unpack[0]      5.412M (± 1.0%) i/s -     27.045M in   5.012499s
+             unpack1      7.185M (± 0.9%) i/s -     35.875M in   5.011588s
+                   with 95.0% confidence
+
+Comparison:
+             unpack1:  7184877.9 i/s
+           unpack[0]:  5412005.1 i/s - 1.33x  (± 0.02) slower
+        unpack.first:  5074389.3 i/s - 1.42x  (± 0.02) slower
+                   with 95.0% confidence
+```

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -170,6 +170,20 @@ Naming/HeredocDelimiterNaming:
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 
+# Keeping with our semantic style we allow use of `and` / `or` conditionals
+# when it is used for control flow:
+#
+#     system("some command") or system("another command")
+#
+# Used in this manner it provides additional semantic clues to the intent of
+# the code. However, when there is a conditional, or the intent is to perform
+# a boolean comparison, the `&&` / `||` style should be used.
+#
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: always, conditionals
+Style/AndOr:
+  EnforcedStyle: conditionals
+
 # These days most people have editors which support unicode and other
 # non-ASCII characters.
 #
@@ -206,6 +220,7 @@ Style/BlockDelimiters:
     - with_object
   FunctionalMethods:
     - each_with_object
+    - find
     - git_source
     - let
     - let!
@@ -217,6 +232,51 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
+
+# The double negation idiom is a common Ruby-ism. All languages have various
+# idioms and part of learning the language is learning the common idioms. Once
+# learning the meaning it is not cryptic as Rubocop implies.
+#
+#   > Double negation converts converts a value to boolean.
+#   >
+#   > It converts "truthy" values to `true` and "falsey" values, `nil` and
+#   > `false`, to `false`.
+#
+# The [Rubocop style guide](https://github.com/rubocop-hq/ruby-style-guide#no-bang-bang)
+# does have a valid complaint about it's use in a conditional:
+#
+#   > you don't need this explicit conversion in the condition of a control
+#   > expression; using it only obscures your intention...
+#   >
+#   > ```ruby
+#   > # bad
+#   > x = 'test'
+#   > # obscure nil check
+#   > if !!x
+#   >   # body omitted
+#   > end
+#   >
+#   > # good
+#   > x = 'test'
+#   > if x
+#   >   # body omitted
+#   > end
+#   > ```
+#
+# This is true and we completely agree. However the check isn't limited to just
+# conditional control expressions. It affects any use of the idiom.
+#
+# We believe using the idiom is completely valid for predicate methods to
+# ensure either a `true` or `false` return, instead of just a "truthy" or
+# "falsey" response. As it is an op it is a bit faster than the alternative of
+# sending `nil?` to the object and more concise than using `obj == nil`. It
+# also works with something that is potentially `false` as expected.
+#
+# As we cannot customize this to only limit it to the conditional control
+# expressions, or instances which may be better replaced with something else
+# (like `blank?`), we are disabling it.
+Style/DoubleNegation:
+  Enabled: false
 
 # Using `case` instead of an `if` expression when the case condition is empty
 # can be more expressive of intent. Using multiple "cases" informs the reader
@@ -298,7 +358,17 @@ Style/NumericPredicate:
   Enabled: false
 
 # Prefer slashes for simple expressions. For multi-line use percent literal
-# to support comments and other advanced features.
+# to support comments and other advanced features. By using the mixed style we
+# are choosing to use `%r{}` for multi-line regexps. In general we are not a
+# fan of single vs multi-line dictating a style. We do make an exception in
+# this case because of the parity the braces give to general code block
+# grouping:
+#
+#     regex = %r{
+#       foo
+#       (bar)
+#       (baz)
+#     }x
 #
 # Configuration parameters: EnforcedStyle, AllowInnerSlashes.
 # SupportedStyles: slashes, percent_r, mixed
@@ -353,6 +423,15 @@ Style/RescueStandardError:
 # Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
+  Enabled: false
+
+# As with regular string literals we have no real preference for this. Forcing
+# one style of strings over others for this case just adds to Rubocop noise and
+# in our experience developer frustration.
+#
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: single_quotes, double_quotes
+Style/StringLiteralsInInterpolation:
   Enabled: false
 
 # We don't feel too strongly about percent vs bracket array style. We tend to

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -157,8 +157,7 @@ Naming/FileName:
 # Blacklist: END, (?-mix:EO[A-Z]{1})
 Naming/HeredocDelimiterNaming:
   Blacklist:
-    - 'END'
-    - '(?-mix:EO[A-EG-Z]{1})'
+    - !ruby/regexp '/(^|\s)(EO[A-EG-Z]{1}|END)(\s|$)/'
 
 # `alias` behavior changes on scope. In general we expect the behavior to be
 # that which is defined by `alias_method`.

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -12,9 +12,6 @@ AllCops:
     - 'bin/yard'
     # Exclude vendored content
     - 'vendor/**/*'
-  Include:
-    - '**/Brewfile'
-    - '**/Rakefile'
 
 # Modifiers should be indented as deep as method definitions, or as deep as the
 # class/module keyword, depending on configuration.

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -35,16 +35,10 @@ Layout/BlockAlignment:
 # first method call is multi-line.
 #
 # See # https://github.com/bbatsov/rubocop/issues/5650
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-# Disabling this until it is fixed to handle multi-line method chains where the
-# first method call is multi-line.
-#
-# See # https://github.com/bbatsov/rubocop/issues/5650
 #
 # Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
+# SupportedStyles: consistent, consistent_relative_to_receiver,
+#                  special_for_inner_method_call, special_for_inner_method_call_in_parentheses
 Layout/FirstParameterIndentation:
   Enabled: false
 

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -59,13 +59,6 @@ Rails/ApplicationRecord:
 Rails/CreateTableWithTimestamps:
   Enabled: false
 
-# Disabling this as it is broken for request specs which use custom headers.
-#
-# Configuration parameters: Include.
-# Include: spec/**/*, test/**/*
-Rails/HttpPositionalArguments:
-  Enabled: false
-
 # The ActiveSupport monkey patches for `present?` are nearly all defiend as:
 #
 #     !blank?

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -59,6 +59,13 @@ Rails/ApplicationRecord:
 Rails/CreateTableWithTimestamps:
   Enabled: false
 
+# Disabling this as it is broken for request specs which use custom headers.
+#
+# Configuration parameters: Include.
+# Include: spec/**/*, test/**/*
+Rails/HttpPositionalArguments:
+  Enabled: false
+
 # The ActiveSupport monkey patches for `present?` are nearly all defiend as:
 #
 #     !blank?

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.55.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.56.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.53.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.54.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.54.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.55.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.56.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.57.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
+  spec.add_runtime_dependency "rubocop", "~> 0.53.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
This updates the common Rubocop config to pull in customizations we've made in our apps. It also locks this to a specific Rubocop version so we have consistency between projects. This way configuration changes will not break when the gem is updated but not the Rubocop version. Lastly, this updates to the latest release of Rubocop adjusting the configuration as necessary.