### PR TITLE
Rubocop updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   `respond_to` / `format` and permitted params methods (Aaron Kromer, #7)
 - Disable Rubocop `Naming/BinaryOperatorParameterName` (Aaron Kromer, #7)
 - Disable Rubocop `Rails/HasAndBelongsToMany` (Aaron Kromer, #7)
+- Exclude Rails app `config/routes.rb` from Rubocop's `Metrics/BlockLength`
+  (Aaron Kromer, #7)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Enhancements
 
-- TODO
+- Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
+  `respond_to` / `format` and permitted params methods (Aaron Kromer, #7)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
   `respond_to` / `format` and permitted params methods (Aaron Kromer, #7)
 - Disable Rubocop `Naming/BinaryOperatorParameterName` (Aaron Kromer, #7)
+- Disable Rubocop `Rails/HasAndBelongsToMany` (Aaron Kromer, #7)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Enhancements
 
-- Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
-  `respond_to` / `format` and permitted params methods (Aaron Kromer, #7)
-- Disable Rubocop `Naming/BinaryOperatorParameterName` (Aaron Kromer, #7)
-- Disable Rubocop `Rails/HasAndBelongsToMany` (Aaron Kromer, #7)
-- Exclude Rails app `config/routes.rb` from Rubocop's `Metrics/BlockLength`
-  (Aaron Kromer, #7)
+- Adjust common Rubocop configuration (Aaron Kromer, #7)
+  - Disable `Naming/BinaryOperatorParameterName`
+- Adjust common Rubocop Rails configuration (Aaron Kromer, #7)
+  - Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
+    `respond_to` / `format` and permitted params methods
+  - Disable `Rails/HasAndBelongsToMany`
+  - Exclude Rails app `config/routes.rb` from `Metrics/BlockLength`
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Bug Fixes
 
-- TODO
+- Add more functional methods to Rubocop config (Aaron Kromer, #7)
+  - `create`
+  - `create!`
+  - `build`
+  - `build!`
 
 
 ## 0.3.0 (June 15, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
   `respond_to` / `format` and permitted params methods (Aaron Kromer, #7)
+- Disable Rubocop `Naming/BinaryOperatorParameterName` (Aaron Kromer, #7)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Adjust common Rubocop configuration (Aaron Kromer, #7)
   - Disable `Naming/BinaryOperatorParameterName`
+  - Disable `Style/RedundantReturn`
 - Adjust common Rubocop Rails configuration (Aaron Kromer, #7)
   - Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
     `respond_to` / `format` and permitted params methods

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -134,6 +134,14 @@ Metrics/LineLength:
     - '\A.{1,78}\s#\s.*\z'
   Max: 100
 
+# This is overly pedantic (only allowing `other` as the parameter name). Ruby
+# core doesn't follow this consistently either. Looking at several classes
+# throughout Ruby core we do often see `other`, but also often `obj` or
+# `other_*`. In some cases, the parameter is named more meaningfully with names
+# like `real`, `numeric`, or `str`.
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
 Naming/FileName:

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -362,6 +362,32 @@ Style/MultilineBlockChain:
 Style/NumericPredicate:
   Enabled: false
 
+# In Ruby every method returns a value. Implicitly this is the value of the
+# last line of the method. This means using `return` is often redundant.
+# However, there isn't anything inherently wrong about doing so. In fact, in
+# some cases it can help with a consistent style in a method:
+#
+#     def transform(value)
+#       return value.call if value.is_a?(Proc)
+#       return value if value.frozen?
+#       return value.dup
+#     end
+#
+# Other times it can add context to a seamingly oddly place value:
+#
+#     def munge(data)
+#       data.slice! 5
+#       return nil
+#     end
+#
+# We often omit the explicit `return` in our code. Though sometimes we include
+# it for improved contextual clues and we don't want Rubocop to complain for
+# those cases.
+#
+# Configuration parameters: AllowMultipleReturnValues.
+Style/RedundantReturn:
+  Enabled: false
+
 # Prefer slashes for simple expressions. For multi-line use percent literal
 # to support comments and other advanced features. By using the mixed style we
 # are choosing to use `%r{}` for multi-line regexps. In general we are not a

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -212,6 +212,10 @@ Style/BlockDelimiters:
     - realtime
     - with_object
   FunctionalMethods:
+    - create
+    - create!
+    - build
+    - build!
     - each_with_object
     - find
     - git_source

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -39,6 +39,52 @@ Metrics/LineLength:
     - '\A#  fk_rails_'
     - '\A#  index_'
 
+# For our Rails apps several of them use the `respond_to` with `format` blocks
+# to handle various mime types (mostly HTML and JSON). Given our `do` / `end`
+# block style for non-functional blocks (which includes both `respond_to` and
+# `format`) the general method limit of is too small. This also applies to the
+# helper methods which define the allowed parameters for the action; especially
+# for larger forms.
+#
+# Here is an example of a minimal controller `update` method which uses the
+# `respond_to` style to support just the HTML and JSON formats:
+#
+#   ```ruby
+#   def update
+#     respond_to do |format|
+#       if @resource.update(resource_params)
+#         format.html do
+#           redirect_to resources_url, notice: 'Resource was successfully updated.'
+#         end
+#         format.json do
+#           render :show, status: :ok, location: @resource
+#         end
+#       else
+#         format.html do
+#           render :edit
+#         end
+#         format.json do
+#           render json: @resource.errors, status: :unprocessable_entity
+#         end
+#       end
+#     end
+#   end
+#   ```
+#
+# We do believe that the default size of 10, which is what we explicitly
+# configure below so there's no confusion, is a good general limit to help
+# encourage a balance between terseness and procedural code. Thus we do not
+# want to raise the limit, instead we just want to exclude these controllers.
+#
+# At this time there is no way for us to exclude just the common controller
+# actions / *_params methods so we exclude the entire file.
+#
+# Configuration parameters: CountComments.
+Metrics/MethodLength:
+  Max: 10
+  Exclude:
+    - 'app/controllers/**/*_controller.rb'
+
 # Ignore subclass parent for one off benchmarks
 #
 # Benchmarks are generally meant to be small and targeted. They often have

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -27,6 +27,7 @@ Documentation:
 
 Metrics/BlockLength:
   Exclude:
+    - 'config/routes.rb'
     - 'spec/rails_helper.rb'
 
 # Rails foreign keys and indexes can get long. We want to ignore our annotation

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -105,6 +105,15 @@ Rails/ApplicationRecord:
 Rails/CreateTableWithTimestamps:
   Enabled: false
 
+# We understand the trade-offs for using the through model versus a lookup
+# table. As such this cop is just noise as it flags only those cases we really
+# do want a lookup table.
+#
+# Configuration parameters: Include.
+# Include: app/models/**/*.rb
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 # The ActiveSupport monkey patches for `present?` are nearly all defiend as:
 #
 #     !blank?


### PR DESCRIPTION
- Add more functional methods to Rubocop config
  - `create`
  - `create!`
  - `build`
  - `build!`
- Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to `respond_to` / `format` and permitted params methods
- Disable Rubocop `Naming/BinaryOperatorParameterName` as it's too pedantic
- Disable Rubocop `Rails/HasAndBelongsToMany` as it only flags cases where we really want lookup tables
