### PR TITLE
Support running system specs in isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - `create!`
   - `build`
   - `build!`
+- Support running system specs in isolation (Aaron Kromer, #9)
 
 
 ## 0.3.0 (June 15, 2018)

--- a/lib/radius/spec/rails.rb
+++ b/lib/radius/spec/rails.rb
@@ -40,7 +40,7 @@ RSpec.configure do |config|
   #   - http://guides.rubyonrails.org/v5.1.4/testing.html#implementing-a-system-test
   #   - https://relishapp.com/rspec/rspec-core/v/3-7/docs/filtering/exclusion-filters
   #   - http://rspec.info/documentation/3.7/rspec-core/RSpec/Core/Configuration.html#filter_run_excluding-instance_method
-  config.filter_run_excluding type: "system"
+  config.filter_run_excluding type: "system" unless config.files_to_run.one?
 
   # Always clear the cache before specs to avoid state leak problems
   config.before do


### PR DESCRIPTION
Currently `system` specs are disabled from the RSpec suite by default. The idea here is to make the average pass through a Rails spec suite faster; since system specs require a browser to run. For apps which include system specs our CI scripts are setup to run them.

One issue with this is that it means someone attempting to write new system specs cannot run them. Simply tagging them with `:focus` won't work due to how the include and exclude filters are applied:

    $ bin/rspec
    Run options:
      include {:focus=>true}
      exclude {:type=>"system"}

    Randomized with seed 34648

    Finished in 0.0007 seconds (files took 5.51 seconds to load)
    0 examples, 0 failures

Nor will running against a single file:

    $ bin/rspec spec/system/some_system_spec.rb

    Run options:
      include {:focus=>true}
      exclude {:type=>"system"}

    Randomized with seed 28864

    Finished in 0.00087 seconds (files took 4.03 seconds to load)
    0 examples, 0 failures

The only way to get it to work is to provide a location inside the desired file to a specific spec or context:

    $ bin/rspec spec/system/some_system_spec.rb:5
    Run options:
      include {:focus=>true, :locations=>{"./spec/system/some_system_spec.rb"=>[5]}}
      exclude {:type=>"system"}

    Randomized with seed 61471

    Some System Specs
      A Context
        testing some javascript
      Another context
        testing javascript under different condition
        some UI web flow

    Finished in 6.25 seconds (files took 3.22 seconds to load)
    3 examples, 0 failures

This adjusts the common Rails config to not exclude `system` specs when there is just a single file. This makes running the spec in isolation easier without requiring additional metadata or a specific file location.

Note this still will not allow several system spec files to be run, even if they are tagged with `:focus`. For that, per the common Rails config, `system` specs need to be included explicitly.