### PR TITLE
Update Rubocop to 0.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Upgrade to Rubocop 0.58.x (Aaron Kromer, #10)
+- Add more custom extra details for customized cops (Aaron Kromer, #10)
 - Adjust common Rubocop configuration
   - Disable `Naming/BinaryOperatorParameterName` (Aaron Kromer, #7)
   - Disable `Style/RedundantReturn` (Aaron Kromer, #7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Upgrade to Rubocop 0.58.x (Aaron Kromer, #10)
 - Adjust common Rubocop configuration (Aaron Kromer, #7)
   - Disable `Naming/BinaryOperatorParameterName`
   - Disable `Style/RedundantReturn`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Enhancements
 
 - Upgrade to Rubocop 0.58.x (Aaron Kromer, #10)
-- Adjust common Rubocop configuration (Aaron Kromer, #7)
-  - Disable `Naming/BinaryOperatorParameterName`
-  - Disable `Style/RedundantReturn`
+- Adjust common Rubocop configuration
+  - Disable `Naming/BinaryOperatorParameterName` (Aaron Kromer, #7)
+  - Disable `Style/RedundantReturn` (Aaron Kromer, #7)
+  - Allow optional leading underscores for memoized instance variable names to
+    support modules wanting to reduce conflicts / collisions. (Aaron Kromer, #10)
 - Adjust common Rubocop Rails configuration (Aaron Kromer, #7)
   - Exclude Rails controllers from Rubocop's `Metrics/MethodLength` due to
     `respond_to` / `format` and permitted params methods

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
 # Modifiers should be indented as deep as method definitions, or as deep as the
 # class/module keyword, depending on configuration.
 #
-# Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
+# Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: outdent, indent
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
@@ -34,7 +34,7 @@ Layout/BlockAlignment:
 # Disabling this until it is fixed to handle multi-line method chains where the
 # first method call is multi-line.
 #
-# See # https://github.com/bbatsov/rubocop/issues/5650
+# See https://github.com/bbatsov/rubocop/issues/5650
 #
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: consistent, consistent_relative_to_receiver,
@@ -83,7 +83,7 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*_spec.rb'
 
-# Often with benchmarking we don't explictly "use" a variable or return value.
+# Often with benchmarking we don't explicitly "use" a variable or return value.
 # We simply need to perform the operation which generates said value for the
 # benchmark.
 #
@@ -93,6 +93,7 @@ Lint/Void:
     - 'benchmarks/**/*'
 
 # Configuration parameters: CountComments, ExcludedMethods, Max.
+# ExcludedMethods: refine
 Metrics/BlockLength:
   Exclude:
     - '**/Rakefile'
@@ -156,7 +157,7 @@ Naming/FileName:
 # for those heredocs which represent "file" text.
 #
 # Configuration parameters: Blacklist.
-# Blacklist: END, (?-mix:EO[A-Z]{1})
+# Blacklist: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))
 Naming/HeredocDelimiterNaming:
   Blacklist:
     - !ruby/regexp '/(^|\s)(EO[A-EG-Z]{1}|END)(\s|$)/'
@@ -199,8 +200,7 @@ Style/AsciiComments:
 # When the return value of the method receiving the block is important prefer
 # `{..}` over `do..end`.
 #
-# Configuration parameters: EnforcedStyle, SupportedStyles, ProceduralMethods,
-#   FunctionalMethods, IgnoredMethods.
+# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.
 # SupportedStyles: line_count_based, semantic, braces_for_chaining
 Style/BlockDelimiters:
   Details: |
@@ -347,7 +347,7 @@ Style/MethodCalledOnDoEndBlock:
 Style/MultilineBlockChain:
   Enabled: false
 
-# Context for this cop is too dependent. Often using the numeric comparision is
+# Context for this cop is too dependent. Often using the numeric comparison is
 # faster. An in certain contexts, Also, depending on the context a numeric
 # comparison is more consistent and can even be more natural:
 #
@@ -373,7 +373,7 @@ Style/NumericPredicate:
 #       return value.dup
 #     end
 #
-# Other times it can add context to a seamingly oddly place value:
+# Other times it can add context to a seemingly oddly place value:
 #
 #     def munge(data)
 #       data.slice! 5
@@ -451,7 +451,7 @@ Style/RescueStandardError:
 # don't view the performance difference to be all that much so we don't care
 # if the style is mixed or double quotes are used for static strings.
 #
-# Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.
+# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Enabled: false
@@ -478,7 +478,7 @@ Style/SymbolArray:
   MinSize: 3
 
 # When ternaries become complex they can be difficult to read due to increased
-# cognative load parsing the expression. Cognative load can increase further
+# cognitive load parsing the expression. Cognitive load can increase further
 # when assignment is involved.
 #
 # Configuration parameters: EnforcedStyle, AllowSafeAssignment.
@@ -487,8 +487,8 @@ Style/TernaryParentheses:
   AllowSafeAssignment: false
   Details: |
     When ternaries become complex they can be difficult to read due to
-    increased cognative load parsing the expression. Cognative load can
-    increase further when assignment is involved. To help reduce this cognative
+    increased cognitive load parsing the expression. Cognitive load can
+    increase further when assignment is involved. To help reduce this cognitive
     use parentheses for complex expressions.
   EnforcedStyle: require_parentheses_when_complex
 

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -13,12 +13,16 @@ AllCops:
     # Exclude vendored content
     - 'vendor/**/*'
 
-# Modifiers should be indented as deep as method definitions, or as deep as the
-# class/module keyword, depending on configuration.
+# We prefer outdented access modifiers as we feel they provide demarcation of
+# the class similar to `rescue` and `ensure` in a method.
 #
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: outdent, indent
 Layout/AccessModifierIndentation:
+  Details: |
+
+    Prefer outdented access modifiers to provide demarcation of the class
+    similar to `rescue` and `ensure` in a method.
   EnforcedStyle: outdent
 
 # Disabling this until it is fixed to support multi-line block chains using the
@@ -51,14 +55,15 @@ Layout/FirstParameterIndentation:
 Layout/IndentHeredoc:
   EnforcedStyle: squiggly
 
-# We tend to indent multi-line operation statements. I think this is because
-# it's tends to be the default style auto-formatted by VIM (which many of us
-# use). It also helps show the continuation of the statement instead of it
+# We tend to indent multi-line operation statements. I think this is because it
+# tends to be the default style auto-formatted by VIM (which many of us use).
+# It also helps show the continuation of the statement instead of it
 # potentially blending in with the start of the next statement.
 #
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: aligned, indented
 Layout/MultilineOperationIndentation:
+  Details: "This helps show expression continuation setting it apart from the following LOC."
   EnforcedStyle: indented
 
 # In our specs Rubocop inconsistently complains when using the block form of
@@ -159,6 +164,10 @@ Naming/FileName:
 # Configuration parameters: Blacklist.
 # Blacklist: (?-mix:(^|\s)(EO[A-Z]{1}|END)(\s|$))
 Naming/HeredocDelimiterNaming:
+  Details: |
+
+    Use meaningful delimiter names to provide context to the text. The only
+    allowed `EO*` variant if `EOF` which has specific meaning for file content.
   Blacklist:
     - !ruby/regexp '/(^|\s)(EO[A-EG-Z]{1}|END)(\s|$)/'
 
@@ -189,6 +198,13 @@ Naming/MemoizedInstanceVariableName:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: prefer_alias, prefer_alias_method
 Style/Alias:
+  Details: |
+
+    Prefer `alias_method` because `alias` behavior changes based on scope.
+
+    See:
+      - https://stackoverflow.com/questions/4763121/should-i-use-alias-or-alias-method
+      - https://blog.bigbinary.com/2012/01/08/alias-vs-alias-method.html
   EnforcedStyle: prefer_alias_method
 
 # Keeping with our semantic style we allow use of `and` / `or` conditionals
@@ -203,6 +219,12 @@ Style/Alias:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: always, conditionals
 Style/AndOr:
+  Details: |
+
+    Use `&&` / `||` for conditionals or general comparison. Use `and` / `or`
+    for control flow to provide additional semantic hints:
+
+        system("some command") or system("another command")
   EnforcedStyle: conditionals
 
 # These days most people have editors which support unicode and other
@@ -426,6 +448,13 @@ Style/RedundantReturn:
 # Configuration parameters: EnforcedStyle, AllowInnerSlashes.
 # SupportedStyles: slashes, percent_r, mixed
 Style/RegexpLiteral:
+  Details: |
+
+    Prefer slashes for simple expressions. Use `%r` for expressions containing
+    slashes and for complex expressions so then can be written across multiple
+    lines (allowing advanced features such as comments). Use of `%r` for
+    expressions spanning multiple lines provides some comprehension parity with
+    general code blocks.
   EnforcedStyle: mixed
 
 # If you only need to rescue a single, or predefined set of exceptions, then
@@ -467,6 +496,21 @@ Style/RegexpLiteral:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: implicit, explicit
 Style/RescueStandardError:
+  Details: |
+
+    If you only need to rescue a single, or predefined set of exceptions, then
+    catch each exception explicitly. When you need to include a general error
+    handler or "catch-all" use the "unspecified rescue":
+
+        begin
+          # do something that may cause a standard error
+        rescue TypeError
+          handle_type_error
+        rescue => e
+          handle_error e
+        end
+
+    Avoid rescuing `Exception` as this may hide system errors.
   EnforcedStyle: implicit
 
 # We generally prefer double quotes but many generators use single quotes. We

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -204,6 +204,7 @@ Style/AsciiComments:
 # SupportedStyles: line_count_based, semantic, braces_for_chaining
 Style/BlockDelimiters:
   Details: |
+
     Use semantic style for blocks:
       - Prefer `do...end` over `{...}` for procedural blocks.
       - Prefer `{...}` over `do...end` for functional blocks.
@@ -315,6 +316,7 @@ Style/EmptyMethod:
 # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
 Style/HashSyntax:
   Details: |
+
     Prefer symbol keys using the 1.9 hash syntax. However, when keys are mixed
     use a consistent mapping style; which generally means using hash rockets.
   EnforcedStyle: ruby19_no_mixed_keys
@@ -328,6 +330,7 @@ Style/HashSyntax:
 # SupportedStyles: line_count_dependent, lambda, literal
 Style/Lambda:
   Details: |
+
     As part of our semantic style we generally use the literal `-> { }` format
     to indicate this is a function with a return value we care about. As this
     cop doesn't have a more flexible setting we prefer the literal syntax to
@@ -486,6 +489,7 @@ Style/SymbolArray:
 Style/TernaryParentheses:
   AllowSafeAssignment: false
   Details: |
+
     When ternaries become complex they can be difficult to read due to
     increased cognitive load parsing the expression. Cognitive load can
     increase further when assignment is involved. To help reduce this cognitive
@@ -504,6 +508,7 @@ Style/TernaryParentheses:
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
 Style/TrailingCommaInArguments:
   Details: |
+
     Always use trailing commas for multiline arguments. This makes git diffs
     easier to read by cutting down on noise when commas are appended. It also
     simplifies adding, removing, and swapping argument orders.
@@ -518,6 +523,7 @@ Style/TrailingCommaInArguments:
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
 Style/TrailingCommaInArrayLiteral:
   Details: |
+
     Always use trailing commas for multiline arrays. This makes git diffs
     easier to read by cutting down on noise when commas are appended. It also
     simplifies adding, removing, and re-arranging the elements.
@@ -530,6 +536,7 @@ Style/TrailingCommaInArrayLiteral:
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
 Style/TrailingCommaInHashLiteral:
   Details: |
+
     Always use trailing commas for multiline hashes. This makes git diffs
     easier to read by cutting down on noise when commas are appended. It also
     simplifies adding, removing, and re-arranging the elements.

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -162,6 +162,25 @@ Naming/HeredocDelimiterNaming:
   Blacklist:
     - !ruby/regexp '/(^|\s)(EO[A-EG-Z]{1}|END)(\s|$)/'
 
+# It is generally a good idea to match the instance variable names with their
+# methods to keep consistent with the attribute reader / writer pattern.
+# However, this can pose an issue in Rails. Most notably, when writing modules
+# that will be used as controller plugins. The reason is that the Rails
+# controllers-to-view interface is ivars. Using a leading underscore can help
+# avoid accidental controller ivar naming conflicts.
+#
+# Configuration parameters: EnforcedStyleForLeadingUnderscores.
+# SupportedStylesForLeadingUnderscores: disallowed, required, optional
+Naming/MemoizedInstanceVariableName:
+  Details: |
+
+    It is generally a good idea to match the instance variable names with their
+    methods to keep consistent with the attribute reader / writer pattern. An
+    exception can be made for modules that want to avoid naming conflicts with
+    classes that include them. In this case a single leading underscore is
+    acceptable.
+  EnforcedStyleForLeadingUnderscores: optional
+
 # `alias` behavior changes on scope. In general we expect the behavior to be
 # that which is defined by `alias_method`.
 #

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -115,11 +115,11 @@ Rails/CreateTableWithTimestamps:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
-# The ActiveSupport monkey patches for `present?` are nearly all defiend as:
+# The ActiveSupport monkey patches for `present?` are nearly all defined as:
 #
 #     !blank?
 #
-# For most of use `unless blank?` reads just as easily as `if present?`.
+# For most of us `unless blank?` reads just as easily as `if present?`.
 # Sometimes contextually, it can read better depending on the branch logic and
 # surrounding context. As `if present?` requires an additional negation and
 # method call it is technically slower. In the general case the perf different
@@ -135,7 +135,7 @@ Rails/Present:
 # We prefer you use the attribute readers and writes. For those special cases
 # where the intent is really to interact with the raw underlying attribute we
 # prefer `read_attribute` and `write_attribute`; as this makes the intent
-# explict. Ideally we'd never use the hash like accessor `[:attr]`.
+# explicit. Ideally we'd never use the hash like accessor `[:attr]`.
 #
 # We disable this cop because it is not configurable.
 #

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.57.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.58.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
- Upgrade to Rubocop 0.58.x
- Add more custom extra details for customized cops
- Adjust common Rubocop configuration
  - Allow optional leading underscores for memoized instance variable names to support modules wanting to reduce conflicts / collisions.
