### PR TITLE
Add model factories to Rails mailers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- TODO
+- Load model factory for specs tagged with 'type: :mailer' (Aaron Kromer, #11)
 
 ### Bug Fixes
 

--- a/lib/radius/spec/rspec.rb
+++ b/lib/radius/spec/rspec.rb
@@ -124,6 +124,11 @@ RSpec.configure do |config|
     config.include Radius::Spec::ModelFactory, type: :job
   end
 
+  config.when_first_matching_example_defined(type: :mailer) do
+    require 'radius/spec/model_factory'
+    config.include Radius::Spec::ModelFactory, type: :mailer
+  end
+
   config.when_first_matching_example_defined(type: :model) do
     require 'radius/spec/model_factory'
     config.include Radius::Spec::ModelFactory, type: :model


### PR DESCRIPTION
Often with mailers various record objects need to be created to pass into the mailer. This is similar to how request specs generally need to create objects which then get rendered in the views.