### PR TITLE
Add common negated matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Enhancements
 
 - Load model factory for specs tagged with 'type: :mailer' (Aaron Kromer, #11)
+- Include the following negated RSpec matchers (Aaron Kromer, #12)
+  - `exclude` / `excluding`
+  - `not_eq`
+  - `not_change`
+  - `not_raise_error` / `not_raise_exception`
 
 ### Bug Fixes
 

--- a/lib/radius/spec/rspec.rb
+++ b/lib/radius/spec/rspec.rb
@@ -144,3 +144,5 @@ RSpec.configure do |config|
     config.include Radius::Spec::ModelFactory, type: :system
   end
 end
+
+require 'radius/spec/rspec/negated_matchers'

--- a/lib/radius/spec/rspec/negated_matchers.rb
+++ b/lib/radius/spec/rspec/negated_matchers.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Define negated matchers for use with composable matchers and compound
+# expectations.
+#
+# @see https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/composing-matchers
+# @see https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/compound-expectations
+RSpec::Matchers.define_negated_matcher :exclude, :include
+RSpec::Matchers.define_negated_matcher :excluding, :including
+RSpec::Matchers.define_negated_matcher :not_eq, :eq
+
+# Allows us to check that a block doesn't raise an exception while also
+# checking for other changes using compound expectations; since you can't chain
+# a negative (`not_to`) with any other matchers
+#
+# @see https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/compound-expectations
+RSpec::Matchers.define_negated_matcher :not_change, :change
+RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error
+RSpec::Matchers.define_negated_matcher :not_raise_exception, :raise_exception

--- a/spec/radius/spec/rspec/negated_matchers_spec.rb
+++ b/spec/radius/spec/rspec/negated_matchers_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe "Custom negated matchers" do
+  specify "`exclude` is the inverse of `include`" do
+    x = [1, 2]
+
+    expect(x).to exclude(3)
+    expect {
+      expect(x).not_to exclude(3)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+
+    expect(x).not_to exclude(1)
+    expect {
+      expect(x).to exclude(1)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  specify "`excluding` is the inverse of `including`" do
+    x = [1, 2]
+
+    expect(x).to excluding(3)
+    expect {
+      expect(x).not_to excluding(3)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+
+    expect(x).not_to excluding(1)
+    expect {
+      expect(x).to excluding(1)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  specify "`not_eq` is the inverse of `eq`" do
+    x = :any_value
+
+    expect(x).to not_eq(:diff_value)
+    expect {
+      expect(x).not_to not_eq(:diff_value)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+
+    expect(x).not_to not_eq(:any_value)
+    expect {
+      expect(x).to not_eq(:any_value)
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  specify "`not_change` is the inverse of `change`" do
+    x = []
+    expect {
+      x.to_s
+    }.to not_change {
+      x
+    }.from([])
+
+    expect {
+      expect {
+        x << :anything
+      }.to not_change {
+        x
+      }
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  specify "`not_raise_error` is the inverse of `raise_error`" do
+    expect { :noop }.to not_raise_error
+
+    expect {
+      expect { raise "Any Error" }.to not_raise_error
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  specify "`not_raise_exception` is the inverse of `raise_exception`" do
+    expect { :noop }.to not_raise_exception
+
+    expect {
+      expect { raise "Any Error" }.to not_raise_exception
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+end


### PR DESCRIPTION
This gem defines the following [negated matchers](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/define-negated-matcher)
to allow for use [composing matchers](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/composing-matchers)
and with [compound expectations](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/compound-expectations).

| Matcher               | Inverse Of |
|-----------------------|------------|
| `exclude`             | [`include`](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/include-matcher) |
| `excluding`           | [`including`](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/include-matcher) |
| `not_eq`              | [`eq`](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/equality-matchers#compare-using-eq-(==)) |
| `not_change`          | [`change`](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/change-matcher) |
| `not_raise_error`     | [`raise_error`](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/raise-error-matcher) |
| `not_raise_exception` | [`raise_exception`](https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/raise-error-matcher) |

#### Composing Matchers

There is no equivalent of `not_to` for composed matchers when only a subset of
the values needs to be negated. The negated matchers allow this type of fine
grain comparison:

  ```ruby
  x = [1, 2, :value]
  expect(x).to contain_exactly(be_odd, be_even, not_eq(:target))
  ```

This also works for verifying / stubbing a message with argument constraints:

  ```ruby
  allow(obj).to receive(:meth).with(1, 2, not_eq(5))
  obj.meth(1, 2, 3)
  expect(obj).to have_received(:meth).with(not_eq(2), 2, 3)
  ```

This is great for verifying option hashes:

  ```ruby
  expect(obj).to have_received(:meth).with(
    some_value,
    excluding(:some_opt, :another_opt),
  )
  ```

#### Compound Negated Matchers

Normally it's not possible to chain to a negative match:

  ```ruby
  a = b = 0
  expect {
    a = 1
  }.not_to change {
    b
  }.from(0).and change {
    a
  }.to(1)
  ```

Fails with:

  ```
  NotImplementedError:
    `expect(...).not_to matcher.and matcher` is not supported, since it creates
    a bit of an ambiguity. Instead, define negated versions of whatever
    matchers you wish to negate with `RSpec::Matchers.define_negated_matcher`
    and use `expect(...).to matcher.and matcher`.
  ```

Per the error the negated matcher allows for the following:

  ```ruby
  a = b = 0
  expect {
    a = 1
  }.to change {
    a
  }.to(1).and not_change {
    b
  }.from(0)
  ```

Similarly, complex expectations can be set on lists:

  ```ruby
  a = %i[red blue green]
  expect(a).to include(:red).and exclude(:yellow)
  expect(a).to exclude(:yellow).and include(:red)
  ```