### PR TITLE
Fix `NoMethodError` on RSpec 3.8 for fixture paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-- TODO
+- Fix `NoMethodError: undefined method 'strip'` when the fixture path is a
+  `Pathname` object (Aaron Kromer, #13)
 
 
 ## 0.4.0 (July 10, 2018)

--- a/lib/radius/spec/rails.rb
+++ b/lib/radius/spec/rails.rb
@@ -7,7 +7,7 @@ require 'rspec/rails'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = ::Rails.root.join("spec", "fixtures")
+  config.fixture_path = ::Rails.root.join("spec", "fixtures").to_path
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
This fixes the following error when using the `fixture_file_upload` helper in request specs:

    NoMethodError:
      undefined method `strip' for #<Pathname:0x00007fab0a970e70>

The issue is caused by a change in RSpec 3.8 to support relative paths when no fixture path is set. This resolves the issue by converting the path to a string when setting it on the RSpec config.