### PR TITLE
Update Rubocop config

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --markup markdown
+--markup-provider redcarpet
 --no-private
 -
 CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 ### Enhancements
 
 - Upgrade to Rubocop 0.59.x (Aaron Kromer, #14)
-- Add more functional method to Rubocop config (Aaron Kromer, #14)
-  - `default_scope`
-  - `filter_sensitive_data`
+- Adjust common Rubocop configuration (Aaron Kromer, #14)
+  - `Layout/EmptyLineAfterGuardClause` is enabled by default
+  - Enable `Rails/SaveBang` to highlight potential lurking issues
+  - Expand `Rails/FindBy` and `Rails/FindEach` to check all `/app` and `/lib`
+  - Add more functional methods
+    - `default_scope`
+    - `filter_sensitive_data`
 - Load model factory for specs tagged with 'type: :mailer' (Aaron Kromer, #11)
 - Include the following negated RSpec matchers (Aaron Kromer, #12)
   - `exclude` / `excluding`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+- Add more functional method to Rubocop config (Aaron Kromer, #14)
+  - `default_scope`
+  - `filter_sensitive_data`
 - Load model factory for specs tagged with 'type: :mailer' (Aaron Kromer, #11)
 - Include the following negated RSpec matchers (Aaron Kromer, #12)
   - `exclude` / `excluding`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Upgrade to Rubocop 0.59.x (Aaron Kromer, #14)
 - Add more functional method to Rubocop config (Aaron Kromer, #14)
   - `default_scope`
   - `filter_sensitive_data`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Add more functional methods
     - `default_scope`
     - `filter_sensitive_data`
+- Add `build!` factory method to compliment `build` to help resolving Rubocop
+  violations for `Rails/SaveBang` (Aaron Kromer, #14)
 - Load model factory for specs tagged with 'type: :mailer' (Aaron Kromer, #11)
 - Include the following negated RSpec matchers (Aaron Kromer, #12)
   - `exclude` / `excluding`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@
 
 ### Bug Fixes
 
-- Fix `NameError: undefined local variable or method `config` for Rails RSpec
+- Fix `NameError: undefined local variable or method config` for Rails RSpec
   configuration (Aaron Kromer, #1)
 - Fix model factory build issue in which registered template attributes, which
   use symbol keys, are not replaced by custom attributes using string keys

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :debug do
 end
 
 group :documentation do
+  gem 'redcarpet', require: false
   gem 'yard', '~> 0.9', require: false
 end
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ constant so no changes need to be made if that's your preference.
 
 Attribute keys may be defined using either strings or symbols. However, they
 will be stored internally as symbols. This means that when an object instance
-is create using the factory the attribute hash will be provided to `new` with
+is created using the factory the attribute hash will be provided to `new` with
 symbol keys.
 
 ##### Dynamic Attribute Values (i.e. Generators)
@@ -418,7 +418,7 @@ There are a few behaviors to note for using the builder:
 
 ##### Optional Block
 
-Both `build` and `create` support providing an optional block. This block is
+Both `build` and `build!` support providing an optional block. This block is
 passed directly to `new` when creating the object. This is to support the
 common Ruby idiom of yielding `self` within initialize:
 
@@ -452,12 +452,6 @@ this feature.
 We suggest that you create instances using the following syntax:
 
   ```ruby
-  created_instance = build("AnyClass").tap(&:save!)
-  ```
-
-Or alternatively:
-
-  ```ruby
   let(:an_instance) { build("AnyClass") }
 
   before do
@@ -465,11 +459,45 @@ Or alternatively:
   end
   ```
 
+Or alternatively:
+
+  ```ruby
+  created_instance = build("AnyClass")
+  created_instance.save!
+  ```
+
 This way it is explicit what objects need to be persisted and in what order.
 
-However, many of our existing projects use a legacy `create` helper. This is
-simply a wrapper around `build.tap(&:save!)`, but it supports omitting the
-`save!` call for objects which do not support it.
+This can get tedious at times, especially for those who only need to create an
+object to embed as an attribute of another object:
+
+```ruby
+collaborator = build("AnotherClass")
+collaborator.save!
+
+# collaborator is not used against directly after this line
+created_instance = build("AnyClass", collaborator: collaborator)
+created_instance.save!
+```
+
+For these cases the `build!` helper is available. This is simply an alias for
+`build.tap(&:save!)`, but it supports omitting the `save!` call for objects
+which do not support it. While it provides a safety guarantee that `save!` will
+be called (instead of potentially `save`) it is less explicit.
+
+```ruby
+created_instance = build("AnyClass", collaborator: build!("AnotherClass"))
+created_instance.save!
+```
+
+We still discourage the use of `build!` directly in `let` blocks for all of the
+above mentioned reasons.
+
+##### Legacy "Creating" Instances
+
+Many of our existing projects use a legacy `create` helper. This is simply an
+alias for `build!`. It is provided only for backwards compatibility support and
+will be removed in a future release. New code should not use this method.
 
   ```ruby
   created_instance = create("AnyClass")

--- a/README.md
+++ b/README.md
@@ -422,22 +422,22 @@ Both `build` and `build!` support providing an optional block. This block is
 passed directly to `new` when creating the object. This is to support the
 common Ruby idiom of yielding `self` within initialize:
 
-  ```ruby
-  class AnyClass
-    def initialize(attrs = {})
-      # setup attrs
-      yield self if block_given?
-    end
+```ruby
+class AnyClass
+  def initialize(attrs = {})
+    # setup attrs
+    yield self if block_given?
   end
+end
 
-  RSpec.describe AnyClass, :model_factory do
-    it "passes the block to the object initializer" do
-      block_capture = nil
-      an_object = build("AnyClass") { |instance| block_capture = instance }
-      expect(block_capture).to be an_object
-    end
+RSpec.describe AnyClass, :model_factory do
+  it "passes the block to the object initializer" do
+    block_capture = nil
+    an_object = build("AnyClass") { |instance| block_capture = instance }
+    expect(block_capture).to be an_object
   end
-  ```
+end
+```
 
 Since Ruby always supports passing a block to a method, even if the method does
 not use the block, it's possible the block will not run if the class being
@@ -451,20 +451,20 @@ this feature.
 
 We suggest that you create instances using the following syntax:
 
-  ```ruby
-  let(:an_instance) { build("AnyClass") }
+```ruby
+let(:an_instance) { build("AnyClass") }
 
-  before do
-    an_instance.save!
-  end
-  ```
+before do
+  an_instance.save!
+end
+```
 
 Or alternatively:
 
-  ```ruby
-  created_instance = build("AnyClass")
-  created_instance.save!
-  ```
+```ruby
+created_instance = build("AnyClass")
+created_instance.save!
+```
 
 This way it is explicit what objects need to be persisted and in what order.
 
@@ -499,9 +499,9 @@ Many of our existing projects use a legacy `create` helper. This is simply an
 alias for `build!`. It is provided only for backwards compatibility support and
 will be removed in a future release. New code should not use this method.
 
-  ```ruby
-  created_instance = create("AnyClass")
-  ```
+```ruby
+created_instance = create("AnyClass")
+```
 
 ### Negated Matchers
 
@@ -524,73 +524,71 @@ There is no equivalent of `not_to` for composed matchers when only a subset of
 the values needs to be negated. The negated matchers allow this type of fine
 grain comparison:
 
-  ```ruby
-  x = [1, 2, :value]
-  expect(x).to contain_exactly(be_odd, be_even, not_eq(:target))
-  ```
+```ruby
+x = [1, 2, :value]
+expect(x).to contain_exactly(be_odd, be_even, not_eq(:target))
+```
 
 This also works for verifying / stubbing a message with argument constraints:
 
-  ```ruby
-  allow(obj).to receive(:meth).with(1, 2, not_eq(5))
-  obj.meth(1, 2, 3)
-  expect(obj).to have_received(:meth).with(not_eq(2), 2, 3)
-  ```
+```ruby
+allow(obj).to receive(:meth).with(1, 2, not_eq(5))
+obj.meth(1, 2, 3)
+expect(obj).to have_received(:meth).with(not_eq(2), 2, 3)
+```
 
 This is great for verifying option hashes:
 
-  ```ruby
-  expect(obj).to have_received(:meth).with(
-    some_value,
-    excluding(:some_opt, :another_opt),
-  )
-  ```
+```ruby
+expect(obj).to have_received(:meth).with(
+  some_value,
+  excluding(:some_opt, :another_opt),
+)
+```
 
 #### Compound Negated Matchers
 
 Normally it's not possible to chain to a negative match:
 
-  ```ruby
-  a = b = 0
-  expect {
-    a = 1
-  }.not_to change {
-    b
-  }.from(0).and change {
-    a
-  }.to(1)
-  ```
+```ruby
+a = b = 0
+expect {
+  a = 1
+}.not_to change {
+  b
+}.from(0).and change {
+  a
+}.to(1)
+```
 
 Fails with:
 
-  ```
-  NotImplementedError:
-    `expect(...).not_to matcher.and matcher` is not supported, since it creates
-    a bit of an ambiguity. Instead, define negated versions of whatever
-    matchers you wish to negate with `RSpec::Matchers.define_negated_matcher`
-    and use `expect(...).to matcher.and matcher`.
-  ```
+    NotImplementedError:
+      `expect(...).not_to matcher.and matcher` is not supported, since it creates
+      a bit of an ambiguity. Instead, define negated versions of whatever
+      matchers you wish to negate with `RSpec::Matchers.define_negated_matcher`
+      and use `expect(...).to matcher.and matcher`.
 
 Per the error the negated matcher allows for the following:
 
-  ```ruby
-  a = b = 0
-  expect {
-    a = 1
-  }.to change {
-    a
-  }.to(1).and not_change {
-    b
-  }.from(0)
-  ```
+```ruby
+a = b = 0
+expect {
+  a = 1
+}.to change {
+  a
+}.to(1).and not_change {
+  b
+}.from(0)
+```
 
 Similarly, complex expectations can be set on lists:
 
-  ```ruby
-  a = %i[red blue green]
-  expect(a).to include(:red).and exclude(:yellow)
-  expect(a).to exclude(:yellow).and include(:red)
-  ```
+```ruby
+a = %i[red blue green]
+expect(a).to include(:red).and exclude(:yellow)
+expect(a).to exclude(:yellow).and include(:red)
+```
 
 ## Development
 

--- a/benchmarks/bm_setup.rb
+++ b/benchmarks/bm_setup.rb
@@ -38,6 +38,7 @@ def as_boolean(val, default: nil)
     false
   else
     raise "Unknown boolean value #{val}" if default.nil?
+
     default
   end
 end

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -266,7 +266,9 @@ Style/BlockDelimiters:
     - create!
     - build
     - build!
+    - default_scope
     - each_with_object
+    - filter_sensitive_data
     - find
     - git_source
     - let

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -282,6 +282,19 @@ Style/BlockDelimiters:
     - proc
     - it
 
+# Prefer `Time` over `DateTime`.
+#
+# While these are not necessarily interchangeable we prefer `Time`. According
+# to the Ruby docs `DateTime` is meant more for historical dates; it also does
+# not consider leap seconds or summer time rules.
+#
+# Lastly, `DateTime` is part of the stdlib which is written in Ruby; where as
+# `Time` is part of core and written in C.
+#
+# Configuration parameters: AllowCoercion
+Style/DateTime:
+  Enabled: true
+
 # The double negation idiom is a common Ruby-ism. All languages have various
 # idioms and part of learning the language is learning the common idioms. Once
 # learning the meaning it is not cryptic as Rubocop implies.
@@ -393,9 +406,10 @@ Style/MethodCalledOnDoEndBlock:
 Style/MultilineBlockChain:
   Enabled: false
 
-# Context for this cop is too dependent. Often using the numeric comparison is
-# faster. An in certain contexts, Also, depending on the context a numeric
-# comparison is more consistent and can even be more natural:
+# Context for this cop is too dependent.
+#
+# Often using the numeric comparison is faster. Also, depending on the context
+# a numeric comparison may produce a more consistent style:
 #
 #     # numeric comparison is more natural and consistent
 #     if n < 0

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -106,6 +106,34 @@ Rails/ApplicationRecord:
 Rails/CreateTableWithTimestamps:
   Enabled: false
 
+# Usage of `find_by` is more expressive of intent than `where.first`. We should
+# check all app code, not just the models to improve intent expression.
+#
+# Since rake tasks often live in `lib` we also check all of lib as well.
+#
+# Configuration parameters: Include.
+# Include: app/models/**/*.rb
+Rails/FindBy:
+  Enabled: true
+  Include:
+    - 'app/**/*.rb'
+    - 'lib/**/*.rb'
+
+# Usage of `each` for large datasets can be a performance issue; specially a
+# drain on system memory. When possible it's better to use `find_each` so that
+# chunks of data are evaluated at a time.
+#
+# We should check all app code, not just the models to help prevent this. Since
+# rake tasks often live in `lib` we also check all of lib as well.
+#
+# Configuration parameters: Include.
+# Include: app/models/**/*.rb
+Rails/FindEach:
+  Enabled: true
+  Include:
+    - 'app/**/*.rb'
+    - 'lib/**/*.rb'
+
 # We understand the trade-offs for using the through model versus a lookup
 # table. As such this cop is just noise as it flags only those cases we really
 # do want a lookup table.
@@ -122,7 +150,7 @@ Rails/HasAndBelongsToMany:
 # For most of us `unless blank?` reads just as easily as `if present?`.
 # Sometimes contextually, it can read better depending on the branch logic and
 # surrounding context. As `if present?` requires an additional negation and
-# method call it is technically slower. In the general case the perf different
+# method call it is technically slower. In the general case the perf difference
 # isn't much but in some cases it matters. Thus, we are not enforcing changing
 # `unless blank?` to `if present?` and are leaving it up to the context to
 # decide which is a better fit.
@@ -143,6 +171,37 @@ Rails/Present:
 # Include: app/models/**/*.rb
 Rails/ReadWriteAttribute:
   Enabled: false
+
+# This ensures we do not ignore potential validation issues in the code. Doing
+# so can lead to strange and surprising bugs where records are expected to
+# be created, or be modified, but are not.
+#
+#     # If author is a new record the book may not be created since the FK is
+#     # invalid. Perhaps omitting other fields, maybe new required fields, is
+#     # an oversight in the book creation as well.
+#     author.save
+#     Book.create(author: author)
+#
+# Or side effects are expected to occur but they do not:
+#
+#     # This is a condensed default Rails scaffold controller for `destroy`.
+#     #
+#     # Once a `has_many` or `has_one` associations is added which specifies
+#     # `dependent: :restrict_with_error` this no longer behaves as expected.
+#     # Given such associations are often added much later in time errors in
+#     # this action are an all to common oversight in Rails.
+#     def destroy
+#       @book.destroy
+#       respond_to do |format|
+#         format.html do
+#           redirect_to books_url, notice: 'Book was successfully destroyed.'
+#         end
+#       end
+#     end
+#
+# Configuration parameters: AllowImplicitReturn, AllowedReceivers.
+Rails/SaveBang:
+  Enabled: true
 
 # According to the Rails docs while the following methods skip validations they
 # only update the specified (single) attribute reducing risks. We'd rather not

--- a/lib/radius/spec/model_factory.rb
+++ b/lib/radius/spec/model_factory.rb
@@ -268,6 +268,7 @@ module Radius
         def safe_transform(value)
           return value.call if value.is_a?(Proc)
           return value if value.frozen?
+
           value.dup
         end
 

--- a/lib/radius/spec/model_factory.rb
+++ b/lib/radius/spec/model_factory.rb
@@ -426,33 +426,46 @@ module Radius
 
       # Convenience wrapper for building, and persisting, a model template.
       #
-      # This is a thin wrapper around `build(name, attrs).tap(&:save!)`. The
-      # persistence message `save!` will only be called on objects which
+      # This is a thin wrapper around:
+      #
+      # ```ruby
+      # build(name, attrs, &block).tap(&:save!)
+      # ```
+      #
+      # The persistence message `save!` will only be called on objects which
       # respond to it.
       #
-      # ### Avoid for New Code
+      # @note It is generally suggested that you avoid using `build!` for new
+      #   code. Instead be explicit about when and how objects are persisted.
+      #   This allows you to have fine grain control over how your data is
+      #   setup.
       #
-      # It is strongly suggested that you avoid using `create` for new code.
-      # Instead be explicit about when and how objects are persisted. This
-      # allows you to have fine grain control over how your data is setup.
+      #   We suggest that you create instances which need to be persisted
+      #   before your specs using the following syntax:
       #
-      # We suggest that you create instances which need to be persisted before
-      # your specs using the following syntax:
+      #   ```ruby
+      #   let(:an_instance) { build("AnyClass") }
       #
-      # ```ruby
-      # let(:an_instance) { build("AnyClass") }
+      #   before do
+      #     an_instance.save!
+      #   end
+      #   ```
       #
-      # before do
-      #   an_instance.save!
-      # end
-      # ```
+      # @param (see .build)
+      # @return (see .build)
+      # @raise (see .build)
+      # @see .build
+      # @see .define_factory
+      def build!(name, custom_attrs = {}, &block)
+        instance = build(name, custom_attrs, &block)
+        instance.save! if instance.respond_to?(:save!)
+        instance
+      end
+
+      # Legacy helper provided for backwards compatibility support.
       #
-      # Alternatively if you really want for the instance be lazy instantiated,
-      # and persisted, pass the appropriate persistence method as the block:
-      #
-      # ```ruby
-      # let(:an_instance) { build("AnyClass", &:save!) }
-      # ```
+      # This provides the same behavior as {.build!} and will be removed in a
+      # future release.
       #
       # @param (see .build)
       # @return (see .build)
@@ -460,9 +473,7 @@ module Radius
       # @see .build
       # @see .define_factory
       def create(name, custom_attrs = {}, &block)
-        instance = build(name, custom_attrs, &block)
-        instance.save! if instance.respond_to?(:save!)
-        instance
+        build!(name, custom_attrs, &block)
       end
     end
   end

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.58.1"
+  spec.add_runtime_dependency "rubocop", "~> 0.59.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/spec/radius/spec/model_factory_spec.rb
+++ b/spec/radius/spec/model_factory_spec.rb
@@ -446,7 +446,7 @@ RSpec.describe Radius::Spec::ModelFactory do
 
       an_instance = nil
       expect {
-        an_instance = Radius::Spec::ModelFactory.create("AnyClass", custom_attrs) { |obj|
+        an_instance = Radius::Spec::ModelFactory.build!("AnyClass", custom_attrs) { |obj|
           block_initialized = obj
         }
       }.to change {
@@ -471,7 +471,7 @@ RSpec.describe Radius::Spec::ModelFactory do
       )
       Radius::Spec::ModelFactory.define_factory "AnyClass"
 
-      an_instance = Radius::Spec::ModelFactory.create(
+      an_instance = Radius::Spec::ModelFactory.build!(
         "AnyClass",
         save_called: false,
       )
@@ -495,7 +495,7 @@ RSpec.describe Radius::Spec::ModelFactory do
       Radius::Spec::ModelFactory.define_factory "AnyClass"
 
       expect {
-        Radius::Spec::ModelFactory.create("AnyClass")
+        Radius::Spec::ModelFactory.build!("AnyClass")
       }.to change {
         call_order
       }.from([]).to(%i[initialize save!])
@@ -509,7 +509,7 @@ RSpec.describe Radius::Spec::ModelFactory do
       }.to raise_error NoMethodError
 
       expect {
-        create(Object)
+        build!(Object)
       }.to raise_error NoMethodError
     end
 
@@ -528,6 +528,14 @@ RSpec.describe Radius::Spec::ModelFactory do
         expect(an_instance).to be_an_instance_of(AnyClass).and have_attributes(
           attr1: "Custom Value",
           attr2: "Any Attr2 Value",
+        )
+      end
+
+      it "includes the `build!` helper" do
+        an_instance = build!("AnyClass", attr2: "Custom Value")
+        expect(an_instance).to be_an_instance_of(AnyClass).and have_attributes(
+          attr1: "Any Attr1 Value",
+          attr2: "Custom Value",
         )
       end
 


### PR DESCRIPTION
- Upgrade to Rubocop 0.59.x
- Adjust common Rubocop configuration
  - `Layout/EmptyLineAfterGuardClause` is enabled by default
  - Enable `Rails/SaveBang` to highlight potential lurking issues
  - Expand `Rails/FindBy` and `Rails/FindEach` to check all `/app` and `/lib`
  - Add more functional methods
    - `default_scope`
    - `filter_sensitive_data`

**NOTE:** Regarding the `Rails/SaveBang` change. This will flag usage of `create` from the model factories. ~~This intentionally does not provide an alias `create!`. This is intended to serve as a soft deprecation to encourage peopling moving to the more explicit style~~ (I ended up deciding an alias is useful for limited cases and called it `build!` see 
cbb1f82):

  ```ruby
  let(:obj) { build(Obj) }

  before do
    obj.save!
  end
  ```