### PR TITLE
Add `using_tempfile` file stub helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Add "temp file" helpers for working with file stubs (Aaron Kromer, #15)
 - Upgrade to Rubocop 0.59.x (Aaron Kromer, #14)
 - Adjust common Rubocop configuration (Aaron Kromer, #14)
   - `Layout/EmptyLineAfterGuardClause` is enabled by default

--- a/lib/radius/spec/rspec.rb
+++ b/lib/radius/spec/rspec.rb
@@ -109,6 +109,11 @@ RSpec.configure do |config|
     config.include Radius::Spec::ModelFactory, :model_factory, :model_factories
   end
 
+  config.when_first_matching_example_defined(:tempfile, :tmpfile) do
+    require 'radius/spec/tempfile'
+    config.include Radius::Spec::Tempfile, :tempfile, :tmpfile
+  end
+
   config.when_first_matching_example_defined(type: :controller) do
     require 'radius/spec/model_factory'
     config.include Radius::Spec::ModelFactory, type: :controller

--- a/lib/radius/spec/tempfile.rb
+++ b/lib/radius/spec/tempfile.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'tempfile'
+
+module Radius
+  module Spec
+    # Temporary file helpers
+    #
+    # These helpers are meant to ease the creation of temporary files to either
+    # stub the data out or provide a location for data to be saved then
+    # verified.
+    #
+    # In the case of file stubs, using these helpers allows you to co-locate
+    # the file data with the specs. This makes it easy for someone to read the
+    # spec and understand the test case; instead of having to find a fixture
+    # file and look at its data. This also makes it easy to change the data
+    # between specs, allowing them to focus on just what they need.
+    #
+    # To make these helpers available require them after the gem:
+    #
+    # ```ruby
+    # require 'radius/spec'
+    # require 'radius/spec/tempfile'
+    # ```
+    #
+    # ### Including Helpers in Specs
+    #
+    # There are multiple ways you can use these helpers. Which method you
+    # choose depends on how much perceived magic/syntactic sugar you want:
+    #
+    #   - call the helpers directly on the module
+    #   - manually include the helper methods in the specs
+    #   - use metadata to auto load this feature and include it in the specs
+    #
+    # When using the metadata option you do not need to explicitly require the
+    # module. This gem registers metadata with the RSpec configuration when it
+    # loads and `RSpec` is defined. When the matching metadata is first used it
+    # will automatically require and include the helpers.
+    #
+    # Any of following metadata will include the factory helpers:
+    #
+    #   - `:tempfile`
+    #   - `:tmpfile`
+    #
+    # @example use a helper directly in specs
+    #   require 'radius/spec/tempfile'
+    #
+    #   RSpec.describe AnyClass do
+    #     it "includes the file helpers" do
+    #       Radius::Spec::Tempfile.using_tempfile do |pathname|
+    #         code_under_test pathname
+    #         expect(pathname.read).to eq "Any written data"
+    #       end
+    #     end
+    #   end
+    # @example manually include the helpers
+    #   require 'radius/spec/tempfile'
+    #
+    #   RSpec.describe AnyClass do
+    #     include Radius::Spec::Tempfile
+    #     it "includes the file helpers" do
+    #       using_tempfile do |pathname|
+    #         code_under_test pathname
+    #         expect(pathname.read).to eq "Any written data"
+    #       end
+    #     end
+    #   end
+    # @example use metadata to auto include the helpers
+    #   RSpec.describe AnyClass do
+    #     it "includes the file helpers", :tempfile do
+    #       using_tempfile do |pathname|
+    #         code_under_test pathname
+    #         expect(pathname.read).to eq "Any written data"
+    #       end
+    #     end
+    #   end
+    # @since 0.5.0
+    module Tempfile
+    module_function
+
+      # Convenience wrapper for managaing temporary files.
+      #
+      # This creates a temporary file and yields its path to the provided
+      # block. When the block returns the temporary file is deleted.
+      #
+      # ### Optional Parameters
+      #
+      # The block is required. All other parameters are optional. All
+      # parameters except `data` are Ruby version dependent and will be
+      # forwarded directly to the stdlib's
+      # {https://ruby-doc.org/stdlib/libdoc/tempfile/rdoc/Tempfile.html#method-c-create
+      # `Tempfile.create`}. The when the `data` parameter is provided it's
+      # contents will be written to the temporary file prior to yielding to the
+      # block.
+      #
+      # @example creating a tempfile to pass to code
+      #   def write_hello_world(filepath)
+      #     File.write filepath, "Hello World"
+      #   end
+      #
+      #   Radius::Spec::Tempfile.using_tempfile do |pathname|
+      #     write_hello_world pathname
+      #   end
+      # @example creating a file stub
+      #   stub_data = "Any file stub data text."
+      #   Radius::Spec::Tempfile.using_tempfile(data: stub_data) do |stubpath|
+      #     # File.read(stubpath)
+      #     # => "Any file stub data text."
+      #     code_under_test stubpath
+      #   end
+      # @example creating a file stub inline
+      #   Radius::Spec::Tempfile.using_tempfile(data: <<~TEXT) do |stubpath|
+      #     Any file stub data text.
+      #   TEXT
+      #     # File.read(stubpath)
+      #     # => "Any file stub data text.\n"
+      #     code_under_test stubpath
+      #   end
+      # @example creating a file stub inline without trailing newline
+      #   Radius::Spec::Tempfile.using_tempfile(data: <<~TEXT.chomp) do |stubpath|
+      #     Any file stub data text.
+      #   TEXT
+      #     # File.read(stubpath)
+      #     # => "Any file stub data text."
+      #     code_under_test stubpath
+      #   end
+      # @example writing binary data inline
+      #   Radius::Spec::Tempfile.using_tempfile(encoding: Encoding::BINARY, data: <<~BIN.chomp) do |binpath|
+      #     \xC8\x90\xC5\x9D\xE1\xB9\x95\xC4\x93\xC4\x89
+      #   BIN
+      #     # File.read(binpath)
+      #     # => "Ȑŝṕēĉ"
+      #     code_under_test binpath
+      #   end
+      # @param args [Object] addition file creation options
+      #
+      #   Passed directly to {https://ruby-doc.org/stdlib/libdoc/tempfile/rdoc/Tempfile.html#method-c-create
+      #   `Tempfile.create`}; see the stdlib docs for details on available
+      #   options.
+      # @param data [String] stub data to write to the file before yielding
+      # @param kwargs [Hash{Symbol => Object}] addition file creation options
+      #
+      #   Passed directly to {https://ruby-doc.org/stdlib/libdoc/tempfile/rdoc/Tempfile.html#method-c-create
+      #   `Tempfile.create`}; see the stdlib docs for details on available
+      #   options.
+      # @yieldparam pathname [Pathname] {https://ruby-doc.org/stdlib/libdoc/pathname/rdoc/Pathname.html path}
+      #   of the created temporary file
+      # @note A block must be provided
+      # @see https://ruby-doc.org/stdlib/libdoc/pathname/rdoc/Pathname.html Pathname
+      # @see https://ruby-doc.org/stdlib/libdoc/tempfile/rdoc/Tempfile.html Tempfile
+      def using_tempfile(*args, data: nil, **kwargs)
+        args << 'tmpfile' if args.empty?
+        ::Tempfile.create(*args, **kwargs) do |f|
+          f.write(data)
+          f.close
+          yield Pathname(f.path)
+        end
+      end
+    end
+  end
+end

--- a/spec/radius/spec/tempfile_spec.rb
+++ b/spec/radius/spec/tempfile_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'radius/spec/tempfile'
+
+RSpec.describe Radius::Spec::Tempfile do
+  context "using the temp file helper in specs" do
+    it "is not included by default" do
+      expect {
+        using_tempfile do
+          # no-op
+        end
+      }.to raise_error NoMethodError
+    end
+
+    describe "via module inclusion" do
+      include Radius::Spec::Tempfile
+
+      it "includes the `using_tempfile` helper" do
+        expect { |b| using_tempfile(&b) }.to yield_control
+      end
+    end
+
+    describe "via matching metadata", ":tempfile", :tempfile do
+      it "includes the `using_tempfile` helper" do
+        expect { |b| using_tempfile(&b) }.to yield_control
+      end
+    end
+
+    describe "via matching metadata", ":tmpfile", :tmpfile do
+      it "includes the `using_tempfile` helper" do
+        expect { |b| using_tempfile(&b) }.to yield_control
+      end
+    end
+  end
+
+  describe "using a tempfile" do
+    it "requires a block" do
+      expect {
+        Radius::Spec::Tempfile.using_tempfile
+      }.to raise_error LocalJumpError
+    end
+
+    it "yields a pathname to the provided block" do
+      expect { |b|
+        Radius::Spec::Tempfile.using_tempfile(&b)
+      }.to yield_with_args(Pathname)
+    end
+
+    it "defaults to creating the tempfile in the OS tempdir" do
+      expect { |b|
+        Radius::Spec::Tempfile.using_tempfile(&b)
+      }.to yield_with_args(
+        be_a_file.and(
+          be_readable
+        ).and(
+          be_writable
+        ).and(
+          have_attributes(to_path: start_with(Dir.tmpdir))
+        )
+      )
+    end
+
+    it "accepts a data string which is written to the file before yielding" do
+      written_data = nil
+      Radius::Spec::Tempfile.using_tempfile(data: <<~DATA) do |pathname|
+        Any temp file data
+      DATA
+
+        written_data = pathname.read
+      end
+
+      expect(written_data).to eq "Any temp file data\n"
+    end
+
+    it "accepts optional options to provide when creating the `Tempfile`", :aggregate_failures do
+      tmp_dir = Pathname(__dir__).join("..", "..", "..", "tmp").expand_path
+      Dir.mkdir tmp_dir unless tmp_dir.exist?
+      dirname = basename = written_data = nil
+
+      Radius::Spec::Tempfile.using_tempfile(
+        %w[custom_name .myext],
+        tmp_dir,
+        encoding: "ISO-8859-1",
+        data: <<~DATA,
+          Résumé
+        DATA
+      ) do |pathname|
+        dirname, basename = pathname.split
+        basename = basename.to_path
+        written_data = pathname.read
+      end
+
+      expect(dirname).to eq tmp_dir
+      expect(basename).to start_with("custom_name").and end_with(".myext")
+      expect(written_data).not_to eq "Résumé\n"
+      expect(written_data).to eq "R\xE9sum\xE9\n"
+    end
+
+    it "deletes the file after the block", :aggregate_failures do
+      tmp_pathname = nil
+      Radius::Spec::Tempfile.using_tempfile do |pathname|
+        tmp_pathname = pathname
+      end
+      expect(tmp_pathname).not_to be_nil
+      expect(tmp_pathname).not_to exist
+
+      err_pathname = nil
+      begin
+        Radius::Spec::Tempfile.using_tempfile do |pathname|
+          err_pathname = pathname
+          raise "Any Error"
+        end
+      rescue # rubocop:disable Lint/HandleExceptions
+        # Ignore b/c we're testing behavior on raise so this is expected
+      end
+      expect(err_pathname).not_to be_nil
+      expect(err_pathname).not_to exist
+    end
+  end
+end


### PR DESCRIPTION
This adds a file stub helper we've used in a few projects. It allows us to co-locate file stub data with the specs. It also allows us to freely change the file stub data between specs without worry that there's another spec which may be affected (which is a concern with file fixtures).

Examples:

- Basic temp file with helper included via metadata

  ```ruby
  RSpec.describe AnyClass do
    it "includes the file helpers", :tempfile do
      using_tempfile do |pathname|
        code_under_test pathname
        expect(pathname.read).to eq "Any written data"
      end
    end
  end
  ```

- Inline file stubbing

  ```ruby
  using_tempfile(data: <<~TEXT) do |stubpath|
    Any file stub data text.
  TEXT
    code_under_test stubpath
  end
  ```

- Binary data stubbing

  ```ruby
  using_tempfile(encoding: Encoding::BINARY, data: <<~BIN.chomp) do |binpath|
    \xC8\x90\xC5\x9D\xE1\xB9\x95\xC4\x93\xC4\x89
  BIN
    # File.read(binpath)
    # => "Ȑŝṕēĉ"
    code_under_test binpath
  end
  ```
