### PR TITLE
Add common VCR configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Enhancements
 
+- Add common VCR configuration (Aaron Kromer, #16)
+  - Filters out `Authorization` headers
+  - Filters out the following sensitive/environment varying `ENV` values, as
+    well as their URL and form encoded variants:
+    - `AWS_ACCESS_KEY_ID`
+    - `AWS_SECRET_ACCESS_KEY`
+    - `GOOGLE_CLIENT_ID`
+    - `GOOGLE_CLIENT_SECRET`
+    - `RADIUS_OAUTH_PROVIDER_APP_ID`
+    - `RADIUS_OAUTH_PROVIDER_APP_SECRET`
+    - `RADIUS_OAUTH_PROVIDER_URL`
 - Add "temp file" helpers for working with file stubs (Aaron Kromer, #15)
 - Upgrade to Rubocop 0.59.x (Aaron Kromer, #14)
 - Adjust common Rubocop configuration (Aaron Kromer, #14)

--- a/README.md
+++ b/README.md
@@ -719,6 +719,61 @@ There are a few additional behaviors to note:
     end
     ```
 
+### Common VCR Configuration
+
+A project must include both [`vcr`](https://rubygems.org/gems/vcr) and
+[`webmock`](https://rubygems.org/gems/webmock) to use this configuration.
+Neither of those gems will be installed as dependencies of this gem. This is
+intended to give projects more flexibility in choosing which additional features
+they will use.
+
+The main `radius/spec/rspec` setup will load the common VCR configuration
+automatically when a spec is tagged with the `:vcr` metadata. This will
+configure VCR to:
+
+  - save specs to `/spec/cassettes`
+
+  - use record mode `once` when a single spec or spec file is run
+
+    This helps ease the development of new specs without requiring any
+    configuration / setting changes.
+
+  - uses record mode `none` otherwise, along setting VCR to fail when unused
+    interactions remain in a cassette
+
+    This is intended to better alert developers to unexpected side effects of
+    changes as any addition or removal of a request will cause a failure.
+
+  - all `Authorization` HTTP headers are filtered by default
+
+    This is a common oversight when recording specs. Often token based
+    authentication is picked up by the other filtered environment settings, but
+    basic authentication is not. Additionally, certain types of digest
+    authentication may cause specs to leak state. This filtering guards all of
+    these cases from accidental credential leak.
+
+  - the following common sensitive, or often environment variable, settings are
+    filtered
+
+    Those settings which often change between developer machines, and even the
+    CI server, can cause for flaky specs. It may also be frustrating for
+    developers to have to adjust their local systems to match others just to
+    get a few specs to pass. This is intended to help mitigate those issues:
+
+    - `AWS_ACCESS_KEY_ID`
+    - `AWS_SECRET_ACCESS_KEY`
+    - `GOOGLE_CLIENT_ID`
+    - `GOOGLE_CLIENT_SECRET`
+    - `RADIUS_OAUTH_PROVIDER_APP_ID`
+    - `RADIUS_OAUTH_PROVIDER_APP_SECRET`
+    - `RADIUS_OAUTH_PROVIDER_URL`
+
+  - a project's local `support/vcr.rb` file will be loaded after the common
+    VCR configuration loads; if it's available
+
+    This allows projects to overwrite common settings if they need to, as well,
+    as add on addition settings or filtering of data.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -106,6 +106,10 @@ Metrics/BlockLength:
     - 'spec/spec_helper.rb'
     - 'spec/**/*_spec.rb'
     - 'spec/support/model_factories.rb'
+  ExcludedMethods:
+    - 'refine'
+    - 'RSpec.configure'
+    - 'VCR.configure'
 
 # We generally prefer to use the default line length of 80. Though sometimes
 # we just need a little extra space because it makes it easier to read.

--- a/lib/radius/spec/rspec.rb
+++ b/lib/radius/spec/rspec.rb
@@ -148,6 +148,14 @@ RSpec.configure do |config|
     require 'radius/spec/model_factory'
     config.include Radius::Spec::ModelFactory, type: :system
   end
+
+  config.when_first_matching_example_defined(:webmock) do
+    require 'webmock/rspec'
+  end
+
+  config.when_first_matching_example_defined(:vcr, :vcr_record, :vcr_record_new) do
+    require 'radius/spec/vcr'
+  end
 end
 
 require 'radius/spec/rspec/negated_matchers'

--- a/lib/radius/spec/vcr.rb
+++ b/lib/radius/spec/vcr.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'webmock/rspec'
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.ignore_localhost = true
+
+  record_mode = case
+                when RSpec.configuration.files_to_run.one?
+                  # When developing new features we often run new specs in
+                  # isolation as we write the code. This is the time to allow
+                  # creating the cassettes.
+                  :once
+                when ENV['CI']
+                  # Never let CI record
+                  :none
+                else
+                  # Default to blocking new requests to catch issues
+                  :none
+                end
+  config.default_cassette_options = {
+    record: record_mode,
+
+    # Required for working proxy
+    update_content_length_header: true,
+
+    # Raise errors when recorded cassettes no longer match interactions
+    allow_unused_http_interactions: false,
+  }
+
+  # Filter out common sensitive or environment specific data
+  %w[
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    GOOGLE_CLIENT_ID
+    GOOGLE_CLIENT_SECRET
+    RADIUS_OAUTH_PROVIDER_APP_ID
+    RADIUS_OAUTH_PROVIDER_APP_SECRET
+    RADIUS_OAUTH_PROVIDER_URL
+  ].each do |secret|
+    config.filter_sensitive_data("<#{secret}>") { ENV[secret] }
+
+    config.filter_sensitive_data("<#{secret}_FORM>") {
+      URI.encode_www_form_component(ENV[secret]) if ENV[secret]
+    }
+
+    config.filter_sensitive_data("<#{secret}_URI>") {
+      ERB::Util.url_encode(ENV[secret]) if ENV[secret]
+    }
+
+    config.filter_sensitive_data('<AUTHORIZATION_HEADER>') { |interaction|
+      interaction.request.headers['Authorization']&.first
+    }
+  end
+end
+
+RSpec.configure do |config|
+  {
+    vcr_record: :once,
+    vcr_record_new: :new_episodes,
+  }.each do |tag, record_mode|
+    config.define_derived_metadata(tag) do |metadata|
+      case metadata[:vcr]
+      when nil, true
+        metadata[:vcr] = { record: record_mode }
+      when Hash
+        metadata[:vcr][:record] = record_mode
+      else
+        raise "Unknown VCR metadata value: #{metadata[:vcr].inspect}"
+      end
+    end
+  end
+
+  config.define_derived_metadata(:focus) do |metadata|
+    # VCR is flagged as falsey
+    next if metadata.key?(:vcr) && !metadata[:vcr]
+
+    case metadata[:vcr]
+    when nil, true
+      metadata[:vcr] = { record: :once }
+    when Hash
+      metadata[:vcr][:record] ||= :once
+    else
+      raise "Unknown VCR metadata value: #{metadata[:vcr].inspect}"
+    end
+  end
+end
+
+# Try to any custom VCR config for the app
+# rubocop:disable Lint/HandleExceptions
+begin
+  require 'support/vcr'
+rescue LoadError
+  # Ignore as this is an optional convenience feature
+end
+# rubocop:enable Lint/HandleExceptions

--- a/spec/cassettes/Radius_Spec_VCR/configures_VCR_to_filter_authorization_headers.yml
+++ b/spec/cassettes/Radius_Spec_VCR/configures_VCR_to_filter_authorization_headers.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - "<AUTHORIZATION_HEADER>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Content-Length:
+      - '606'
+    body:
+      encoding: ASCII-8BIT
+      string: "Basic Response"
+    http_version:
+  recorded_at: Tue, 25 Sep 2018 17:06:36 GMT
+- request:
+    method: get
+    uri: http://example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - "<AUTHORIZATION_HEADER>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '606'
+    body:
+      encoding: ASCII-8BIT
+      string: "JSON Response"
+    http_version:
+  recorded_at: Tue, 25 Sep 2018 17:06:36 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/Radius_Spec_VCR/configures_VCR_to_filter_common_data_even_when_encoded.yml
+++ b/spec/cassettes/Radius_Spec_VCR/configures_VCR_to_filter_common_data_even_when_encoded.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://www.example.com/search?gid=<GOOGLE_CLIENT_ID_URI>
+    body:
+      encoding: US-ASCII
+      string: secret=<GOOGLE_CLIENT_SECRET_FORM>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Content-Length:
+      - '345'
+    body:
+      encoding: UTF-8
+      string: "Custom Response"
+    http_version:
+  recorded_at: Tue, 25 Sep 2018 16:01:34 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/Radius_Spec_VCR/configures_VCR_to_filter_common_secret_and_environment_data.yml
+++ b/spec/cassettes/Radius_Spec_VCR/configures_VCR_to_filter_common_secret_and_environment_data.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<RADIUS_OAUTH_PROVIDER_URL>/?aws_id=<AWS_ACCESS_KEY_ID>"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '25'
+    body:
+      encoding: UTF-8
+      string: '{"client_id":"<GOOGLE_CLIENT_ID>"}'
+    http_version:
+  recorded_at: Tue, 25 Sep 2018 15:10:46 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/unused_interactions.yml
+++ b/spec/cassettes/unused_interactions.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.example.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Content-Length:
+      - '606'
+    body:
+      encoding: ASCII-8BIT
+      string: "This should be unused"
+    http_version:
+  recorded_at: Tue, 25 Sep 2018 16:32:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/radius/spec/vcr_spec.rb
+++ b/spec/radius/spec/vcr_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'radius/spec/vcr'
+
+RSpec.describe "Radius::Spec::VCR", :vcr do
+  it "loads 'spec/support/vcr.rb' by default" do
+    expect(TEMP_SPEC_VCR_LOAD_CHECK).to eq true
+  end
+
+  it "configures VCR to filter common secret and environment data" do
+    ENV['AWS_ACCESS_KEY_ID'] = 'Any-AWS-Access-Key'
+    ENV['RADIUS_OAUTH_PROVIDER_URL'] = 'https://any.example.url'
+    ENV['GOOGLE_CLIENT_ID'] = 'Any-Google-Client-ID'
+
+    uri = URI('https://any.example.url?aws_id=Any-AWS-Access-Key')
+    response = Net::HTTP.get_response(uri)
+
+    # Verify expected cassette was used
+    expect(response.body).to eq '{"client_id":"Any-Google-Client-ID"}'
+
+    expect(File.read(VCR.current_cassette.file)).not_to include(
+      "Any-AWS-Access-Key",
+      "Any-Google-Client-ID",
+      "https://any.example.url",
+    )
+  end
+
+  it "configures VCR to filter common data even when encoded" do
+    ENV['GOOGLE_CLIENT_ID'] = 'Any Google Client ID'
+    ENV['GOOGLE_CLIENT_SECRET'] = 'Any Google Secret'
+
+    uri = URI('http://www.example.com/search')
+    uri.query = URI.encode_www_form(gid: 'Any Google Client ID')
+    response = Net::HTTP.post_form(uri, 'secret' => 'Any Google Secret')
+
+    # Verify expected cassette was used
+    expect(response.body).to eq 'Custom Response'
+
+    expect(File.read(VCR.current_cassette.file)).not_to include(
+      'Any+Google+Client+ID',       # Form encoded
+      'Any%20Google%20Client%20ID', # URL encoded
+      'Any+Google+Secret',          # Form encoded
+      'Any%20Google%20Secret',      # URL encoded
+    )
+  end
+
+  it "configures VCR to filter authorization headers" do
+    uri = URI('http://example.com')
+    basic_auth_response = Net::HTTP.start(uri.hostname, uri.port) { |http|
+      req = Net::HTTP::Get.new(uri)
+      req.basic_auth 'user', 'pass'
+      http.request(req)
+    }
+
+    # Verify expected cassette was used
+    expect(basic_auth_response.body).to eq 'Basic Response'
+    expect(File.read(VCR.current_cassette.file)).not_to include('Basic dXNlcjpwYXNz')
+
+    json_auth_response = Net::HTTP.start(uri.hostname, uri.port) { |http|
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = 'Bearer ANY-AUTH-TOKEN'
+      req['Content-Type'] = 'application/json'
+      http.request(req)
+    }
+
+    # Verify expected cassette was used
+    expect(json_auth_response.body).to eq 'JSON Response'
+    expect(File.read(VCR.current_cassette.file)).not_to include('Bearer ANY-AUTH-TOKEN')
+  end
+
+  it "configures VCR to raise on unused HTTP interactions" do
+    expect {
+      # Originally recorded: Net::HTTP.get(URI("http://www.example.com"))
+      VCR.use_cassette("unused_interactions", exclusive: true) do
+        # No-op
+      end
+    }.to raise_error VCR::Errors::Error
+  end
+
+  it "allows the record mode to be set via custom metadata", vcr: { record: :none } do
+    expect {
+      Net::HTTP.get(URI("http://www.example.com"))
+    }.to raise_error VCR::Errors::Error
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+TEMP_SPEC_VCR_LOAD_CHECK = true


### PR DESCRIPTION
A project must include both [`vcr`](https://rubygems.org/gems/vcr) and [`webmock`](https://rubygems.org/gems/webmock) to use this configuration.  Neither of those gems will be installed as dependencies of this gem. This is intended to give projects more flexibility in choosing which additional features they will use.

The main `radius/spec/rspec` setup will load the common VCR configuration automatically when a spec is tagged with the `:vcr` metadata. This will configure VCR to:

  - save specs to `/spec/cassettes`

  - use record mode `once` when a single spec or spec file is run

    This helps ease the development of new specs without requiring any configuration / setting changes.

  - uses record mode `none` otherwise, along setting VCR to fail when unused interactions remain in a cassette

    This is intended to better alert developers to unexpected side effects of changes as any addition or removal of a request will cause a failure.

  - all `Authorization` HTTP headers are filtered by default

    This is a common oversight when recording specs. Often token based authentication is picked up by the other filtered environment settings, but basic authentication is not. Additionally, certain types of digest authentication may cause specs to leak state. This filtering guards all of these cases from accidental credential leak.

  - the following common sensitive, or often environment variable, settings are filtered

    Those settings which often change between developer machines, and even the CI server, can cause for flaky specs. It may also be frustrating for developers to have to adjust their local systems to match others just to get a few specs to pass. This is intended to help mitigate those issues:

    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `GOOGLE_CLIENT_ID`
    - `GOOGLE_CLIENT_SECRET`
    - `RADIUS_OAUTH_PROVIDER_APP_ID`
    - `RADIUS_OAUTH_PROVIDER_APP_SECRET`
    - `RADIUS_OAUTH_PROVIDER_URL`

  - a project's local `support/vcr.rb` file will be loaded after the common VCR configuration loads; if it's available

    This allows projects to overwrite common settings if they need to, as well, as add on addition settings or filtering of data.