### PR TITLE
Updates to Rubocop customizations

### DIFF
--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -29,6 +29,37 @@ Layout/AccessModifierIndentation:
     similar to `rescue` and `ensure` in a method.
   EnforcedStyle: outdent
 
+# Rubocop 0.60.0 changed how it handled value alignments in this cop. This
+# breaks our preference for wanting keys to be aligned, but allowing values to
+# either use the `key` or `table` style:
+#
+#     key_style = {
+#       key: :value,
+#       another: :value,
+#       yet_another: :value
+#     }
+#     table_style = {
+#       key:         :value,
+#       another:     :value
+#       yet_another: :value
+#     }
+#
+# This is logged with Rubocop: https://github.com/rubocop-hq/rubocop/issues/6410
+#
+# Until Rubocop resolves this we've decided to enforce the key style so that we
+# do not lose all associated formatting checks. Additionally, in response to
+# the referenced issue the Rubocop disables the alignment check by default. To
+# continue using it we force enable it here.
+#
+# Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.
+# SupportedHashRocketStyles: key, separator, table
+# SupportedColonStyles: key, separator, table
+# SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
+Layout/AlignHash:
+  Enabled: true
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+
 # Disabling this until it is fixed to support multi-line block chains using the
 # semantic style.
 #

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -111,7 +111,9 @@ Metrics/BlockLength:
     - 'spec/**/*_spec.rb'
     - 'spec/support/model_factories.rb'
   ExcludedMethods:
+    - 'chdir'
     - 'refine'
+    - 'Capybara.register_driver'
     - 'RSpec.configure'
     - 'VCR.configure'
 

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -4,12 +4,16 @@ AllCops:
     # Exclude generated binstubs
     - 'bin/bundle'
     - 'bin/bundler-travis'
+    - 'bin/pronto'
     - 'bin/pry'
     - 'bin/rake'
     - 'bin/rspec'
     - 'bin/rubocop'
     - 'bin/travis'
+    - 'bin/webpack'
+    - 'bin/webpack-dev-server'
     - 'bin/yard'
+    - 'bin/yarn'
     # Exclude vendored content
     - 'vendor/**/*'
 

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -27,6 +27,8 @@ Documentation:
 
 Metrics/BlockLength:
   Exclude:
+    - 'bin/setup'
+    - 'bin/update'
     - 'config/routes.rb'
     - 'spec/rails_helper.rb'
 


### PR DESCRIPTION
This mostly adds more binstubs and configuration blocks to be ignored.

The other notable change is the need to now customize `Layout/AlignHash`. Rubocop 0.60.0 changed how it handled value alignments in this cop. This breaks our preference for wanting keys to be aligned, but allowing values to either use the `key` or `table` style:

```ruby
key_style = {
  key: :value,
  another: :value,
  yet_another: :value
}
table_style = {
  key:         :value,
  another:     :value
  yet_another: :value
}
```

Ref [Rubocop `Layout/AlignHash` docs](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutalignhash)

To continue to get some value out of alignment checks we've decided to stick to the `key` style. Across repos this setting requires less changes for us. Lastly, we force enable the style so that we're ready for when the next release is made.