### PR TITLE
Add more custom exclusions for Rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Enhancements
 
-- Exclude more bundler binstubs from Rubocop (Aaron Kromer, #18)
+- Exclude more bundler binstubs from Rubocop (Aaron Kromer, #18, #20)
 - Exclude `chdir` and `Capybara.register_driver` configuration blocks from
   `Metrics/BlockLength` checks (Aaron Kromer, #18)
+- Exclude gem specs from block and line length metrics (Aaron Kromer, #20)
 - Standardize on key style of `Layout/AlignHash` (Aaron Kromer, #18)
 
 ### Bug Fixes

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'bin/bundler-travis'
     - 'bin/pronto'
     - 'bin/pry'
+    - 'bin/radius-cli'
     - 'bin/rake'
     - 'bin/rspec'
     - 'bin/rubocop'
@@ -145,6 +146,7 @@ Metrics/BlockLength:
     - 'chdir'
     - 'refine'
     - 'Capybara.register_driver'
+    - 'Gem::Specification.new'
     - 'RSpec.configure'
     - 'VCR.configure'
 
@@ -180,6 +182,8 @@ Metrics/LineLength:
     # Attempt at trailing comments
     - '\A.{1,78}\s#\s.*\z'
   Max: 100
+  Exclude:
+    - '**/*.gemspec'
 
 # This is overly pedantic (only allowing `other` as the parameter name). Ruby
 # core doesn't follow this consistently either. Looking at several classes


### PR DESCRIPTION
We've released a new internal CLI gem. We want the bundled binstub excluded from the checks. Additionally, gem specs can get long so we do not want that flagged by block or line length metrics.