### PR TITLE
Support Rubygems 3.0

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -15,7 +15,7 @@ bin/rspec
 # bundle-audit provides patch-level verification for Bundler
 # https://github.com/rubysec/bundler-audit.
 echo " ---> Running bundler-audit"
-gem install --no-rdoc --no-ri bundler-audit
+gem install --no-document bundler-audit
 bundle-audit check --update
 
 # Run style checker


### PR DESCRIPTION
This updates the `bin/ci` script to support Rubygems 3.0. This version changed the CLI flags for documentation. The new flag is `--no-document` and it will not install either rdoc or ri by default.