### PR TITLE
Updates for newer Rubocop

### DIFF
--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -79,7 +79,7 @@ Layout/BlockAlignment:
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: consistent, consistent_relative_to_receiver,
 #                  special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 
 # This project only uses newer Ruby versions which all support the "squiggly"

--- a/lib/radius/spec/version.rb
+++ b/lib/radius/spec/version.rb
@@ -2,6 +2,6 @@
 
 module Radius
   module Spec
-    VERSION = "0.6.pre"
+    VERSION = "0.7.pre"
   end
 end

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.59.1"
+  spec.add_runtime_dependency "rubocop", "~> 0.59"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
As part of setting up a new Rails 6 app, there were a few things that needed to be updated in this gem for running Rubocop


#### Relax Rubocop dependency version.

This allows us to use the latest Rubocop v0.74, which was needed with Rails 6 and Pronto updates.


#### Rename `IndentFirstArgument` cop.

This was changed in Rubocop v0.68 and fixes and error on the current Rubocop version v0.74:

```
Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/IndentFirstArgument`.
(obsolete configuration found in /Users/csexton/.gem/ruby/2.6.2/gems/radius-spec-0.2.1/common_rubocop.yml, please update it)
```