### PR TITLE
Update to Rubocop 0.73.0 and Rubocop-Rails 2.2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_mode:
     - Exclude
     - IgnoredPatterns
 
-inherit_from: common_rubocop.yml
+inherit_from: common_rubocop_rails.yml
 
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
   - "bin/ci-code-review"
 script: bin/ci
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 ### Enhancements
 
-- TODO
+- Adjust common Rubocop configuration (Aaron Hill, Aaron Kromer, Ben Reynold,
+  Chris Hoffman, James Nebeker #24)
+  - Target Ruby 2.7 by default
+  - Enable `Lint/HeredocMethodCallPosition` by default
+  - Use `StandardError` for the suggested parent classes of errors
+  - Bump metric check maximums to provide a little more wiggle room
+  - Disable `Naming/RescuedExceptionsVariableName` by default
+- Adjust common Rubocop Rails configuration (Aaron Hill, Aaron Kromer, Ben
+  Reynold, Chris Hoffman, James Nebeker #24)
+  - Disable `Rails/IgnoredSkipActionFilterOption` by default
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+- Upgrade to Rubocop 0.73.x (Aaron Hill, Aaron Kromer, Ben Reynold, Chris
+  Hoffman, James Nebeker #24)
+- Upgrade to Rubocop Rails 2.2.x (Aaron Hill, Aaron Kromer, Ben Reynold, Chris
+  Hoffman, James Nebeker #24)
 - Adjust common Rubocop configuration (Aaron Hill, Aaron Kromer, Ben Reynold,
   Chris Hoffman, James Nebeker #24)
   - Target Ruby 2.7 by default

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5.0
+  TargetRubyVersion: 2.7.0
   Exclude:
     # Exclude generated binstubs
     - 'bin/bundle'
@@ -79,7 +79,10 @@ Layout/BlockAlignment:
 # Configuration parameters: EnforcedStyle, IndentationWidth.
 # SupportedStyles: consistent, consistent_relative_to_receiver,
 #                  special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-Layout/FirstParameterIndentation:
+#
+# TODO: At some point this is split into both Layout/FirstArgumentIndentation
+# and Layout/FirstParameterIndentation
+Layout/IndentFirstArgument:
   Enabled: false
 
 # This project only uses newer Ruby versions which all support the "squiggly"
@@ -124,6 +127,31 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*_spec.rb'
 
+# We prefer to enforce a consistent usage for readability
+#
+#     <<~SQL.strip
+#       bar
+#     SQL
+#
+#     display(<<~SQL.strip)
+#       bar
+#     SQL
+#
+# Alternatively, refactoring the heredoc into a local also improves
+# readability:
+#
+#     custom_sql = <<~SQL
+#       bar
+#     SQL
+#     display(custom_sql.strip)
+Lint/HeredocMethodCallPosition:
+  Enabled: true
+
+# We prefer people suggesting people subclass `StandardError` for their custom
+# exceptions as this is a relatively common Ruby idiom.
+Lint/InheritException:
+  EnforcedStyle: standard_error
+
 # Often with benchmarking we don't explicitly "use" a variable or return value.
 # We simply need to perform the operation which generates said value for the
 # benchmark.
@@ -132,6 +160,15 @@ Lint/AmbiguousBlockAssociation:
 Lint/Void:
   Exclude:
     - 'benchmarks/**/*'
+
+Metrics/AbcSize:
+  # TODO: When we are able to upgrade to Rubocop 1.5.0 we want to enable the
+  # following `CountRepeatedAttributes` option. We often find the
+  # multi-references to the same object to be necessary for reability and that
+  # for our team it does not increase complexity.
+  #
+  # CountRepeatedAttributes: false
+  Max: 17
 
 # Configuration parameters: CountComments, ExcludedMethods, Max.
 # ExcludedMethods: refine
@@ -146,7 +183,6 @@ Metrics/BlockLength:
     - 'chdir'
     - 'refine'
     - 'Capybara.register_driver'
-    - 'Gem::Specification.new'
     - 'RSpec.configure'
     - 'VCR.configure'
 
@@ -184,6 +220,12 @@ Metrics/LineLength:
   Max: 100
   Exclude:
     - '**/*.gemspec'
+
+# TODO: Remove this when we get to 0.89.0 as the new default max is 8
+#
+# Configuration parameters: IgnoredMethods, Max
+Metrics/PerceivedComplexity:
+  Max: 8
 
 # This is overly pedantic (only allowing `other` as the parameter name). Ruby
 # core doesn't follow this consistently either. Looking at several classes
@@ -235,6 +277,13 @@ Naming/MemoizedInstanceVariableName:
     acceptable.
   EnforcedStyleForLeadingUnderscores: optional
 
+# We don't really care about this check. Sometimes using something simple such
+# as `err` is just fine. Other times it may improve readability to have a more
+# descriptive name. We feel this is a personal judgement call and not something
+# that needs to be enforced.
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
 # `alias` behavior changes on scope. In general we expect the behavior to be
 # that which is defined by `alias_method`.
 #
@@ -284,7 +333,10 @@ Style/AsciiComments:
 #   - Prefer `{...}` over `do...end` for functional blocks.
 #
 # When the return value of the method receiving the block is important prefer
-# `{..}` over `do..end`.
+# `{...}` over `do...end`.
+#
+# Some people enjoy the compact readability of `{...}` for one-liners so we
+# allow that style as well.
 #
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.
 # SupportedStyles: line_count_based, semantic, braces_for_chaining
@@ -297,6 +349,7 @@ Style/BlockDelimiters:
 
     When the return value of the method receiving the block is important prefer
     `{..}` over `do..end`.
+  AllowBracesOnProceduralOneLiners: true
   Enabled: true
   EnforcedStyle: semantic
   ProceduralMethods:

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -1,13 +1,11 @@
+require: rubocop-rails
+
 inherit_mode:
   merge:
     - Exclude
     - IgnoredPatterns
 
 inherit_from: common_rubocop.yml
-
-# Enable additional Rails cops
-Rails:
-  Enabled: true
 
 AllCops:
   Exclude:

--- a/common_rubocop_rails.yml
+++ b/common_rubocop_rails.yml
@@ -145,6 +145,13 @@ Rails/FindEach:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+# We find the combo `:only` and `:if` readable. While the `:except` and `:if`
+# combo is easier to read as a combined proc. As a team we are fine with
+# handling this in PR reviews, until such time which Rubocop provides an option
+# for us to configure this.
+Rails/IgnoredSkipActionFilterOption:
+  Enabled: false
+
 # The ActiveSupport monkey patches for `present?` are nearly all defined as:
 #
 #     !blank?

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.62.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.71.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "rake", ">= 12.0", "< 14.0"
 end

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop", "~> 0.73.0"
   spec.add_runtime_dependency "rubocop-rails", "~> 2.2.1"
 
-  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", ">= 12.0", "< 14.0"
 end

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.71.0"
+  spec.add_runtime_dependency "rubocop", "~> 0.73.0"
+  spec.add_runtime_dependency "rubocop-rails", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", ">= 12.0", "< 14.0"


### PR DESCRIPTION
This updates us to Rubocop 0.73.0 and cross the threshold for when the Rails checks we moved into a dedicated gem. This includes the new gem and puts us at version 2.2.1 for it.

We're pushing to update all of our apps to Ruby 2.7 so we're going to be setting that as the default `TargetRubyVersion` moving forward.

This enables two additional lint checks which match our teams preferred styles. Similarly, we disable two checks because they are either overly opinionated for something we do not care about or do not provide us enough configuration options to support our style.

Lastly, we slightly increase the complexity counts to give us a bit more wiggle room in our code. Most of our code is for Rails apps which can sometimes require the extra room. We considered moving these changes to the Rails only configuration, but they were small enough increases we decided to make them part of the common configuration.

A note regarding the change from Layout/FirstParameterIndentation to Layout/IndentFirstArgument. The current version of Rubocop claims:

    Error: The `Layout/FirstParameterIndentation` cop has been renamed to
    `Layout/IndentFirstArgument`.

However, based on the most recent version of Rubocop cop, the original check still exists. So at some point between where we are now and the most recent version this check split. One of the checks which came out of it was named similar to the name we had been using. When we reach that point we'll circle back around and re-evaluate the checks.