### PR TITLE
Add a few more RSpec default config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,18 @@
   - Configure multiple metrics to use the `CountAsOne` option for array, hash
     and heredocs
   - Disable `Style/SlicingWithRange` as we do not care about the style
+- Includes new `shared_example` / `shared_context` inclusion aliases
+  `has_behavior` and `it_has_behavior` for behavior driven development language
+  (Aaron Kromer, Ben Reynolds #28)
 
 ### Bug Fixes
 
 - TODO
+
+### Breaking Change
+
+- Change the default behavior from `:warn` to `:raise` for RSpec expectations
+  behavior `on_potential_false_positives` (Aaron Kromer, Ben Reynolds #28)
 
 
 ## 0.8.0 (August 26, 2021)

--- a/lib/radius/spec/rspec.rb
+++ b/lib/radius/spec/rspec.rb
@@ -22,6 +22,10 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+
+    # The default is to warn, but this normally just gets ignored by
+    # developers. It's best to fix the problem then live with the warning.
+    expectations.on_potential_false_positives = :raise
   end
 
   # rspec-mocks config goes here. You can use an alternate test double
@@ -100,6 +104,11 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # Common shared_example / shared_context inclusion alias for behavior driven
+  # development
+  config.alias_it_should_behave_like_to :has_behavior
+  config.alias_it_should_behave_like_to :it_has_behavior, 'has behavior:'
 
   config.when_first_matching_example_defined(
     :model_factory,


### PR DESCRIPTION
These options were extracted from one of our projects. Changing from `:warn` to `:raise` for the `raise_error` matcher reduces warning noise in the RSpec output (always good to have no warnings). The example/context inclusion aliases will allow people to use BDD style lexicon in their testing.
