### PR TITLE
Update to Rubocop 0.90.0 and Rubocop-Rails 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,31 @@
 
 ### Enhancements
 
-- Upgrade to Rubocop Rails 2.8.x (Aaron Kromer, Ben Reynolds, James Nebeker, JC Avena, Sam Kim, Alex
-  Stone #30)
-- Adjust common Rubocop Rails configuration (Aaron Kromer, Ben Reynolds, James Nebeker, JC Avena,
-  Sam Kim, Alex Stone #30)
+- Upgrade to Rubocop Rails 2.8.x (Aaron Hill, Aaron Kromer, Ben Reynolds, James Nebeker, JC Avena, Sam Kim, Alex
+  Stone #30, #32)
+- Adjust common Rubocop Rails configuration (Aaron Hill, Aaron Kromer, Ben Reynolds, James Nebeker, JC Avena,
+  Sam Kim, Alex Stone #30, #32)
+  - Enable `Rails/AttributeDefaultBlockValue` by default
+  - Enable `Rails/ArelStar` by default
   - Enable `Rails/DefaultScope` by default
   - Enable `Rails/FindById` by default
   - Enable `Rails/PluckId` by default
+  - Enable `Rails/WhereEquals` by default
   - Use the more aggressive `aggressive` check for `Rails/PluckInWhere`
   - Use the more aggressive `aggressive` check for `Rails/ShortI18n`
   - Switch to new `AllowedMethods` attribute name for `Rails/SkipsModelValidations`
   - Disable `Rails/SquishedSQLHeredocs` by default
+- Adjust common Rubocop configuration (Aaron Hill, Aaron Kromer, JC Avena, Sam
+  Kim #32)
+  - Enable `Style/ClassMethodsDefinitions` by default
+  - Enable `Style/CombinableLoops` by default
+  - Enable `Style/KeywordParametersOrder` by default
+  - Enable `Style/RedundantSelfAssignment` by default
+  - Enable `Style/SoleNestedConditional` by default
+  - Enable `Lint/DuplicateRequire` by default
+  - Enable `Lint/EmptyFile` by default
+  - Enable `Lint/TrailingCommaInAttributeDeclaration` by default
+  - Enable `Lint/UselessMethodDefinition` by default
 
 ### Bug Fixes
 

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   # version by version without having to worry about adding an entry for each
   # new "enabled by default" check. If we want to jump multiple versions and
   # wish to be notified of all the enw check, then we'll need to change
-  # `NewCops` to `pending.
+  # `NewCops` to `pending`.
   NewCops: enable
   Exclude:
     # Exclude generated binstubs
@@ -394,6 +394,15 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
+
+# As a team we prefer the more explicit `def self.method_name` style. We find
+# the explicitness easier to read and grep for on the CLI.
+#
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: def_self, self_class
+Style/ClassMethodsDefinitions:
+  Enabled: true
+  EnforcedStyle: def_self
 
 # Prefer `Time` over `DateTime`.
 #

--- a/lib/radius/spec/model_factory.rb
+++ b/lib/radius/spec/model_factory.rb
@@ -110,6 +110,14 @@ module Radius
       class TemplateNotFound < KeyError; end
 
       class << self
+        # rubocop:disable Style/ClassMethodsDefinitions
+        # Style Note: We are using this class method style because we need to
+        # call `alias_method` within this module's singleton class context.
+        # Ruby did not introduce access to `singleton_class` until 2.7. Once we
+        # drop support for Ruby < 2.7 we can switch styles and use:
+        #
+        #     singleton_class.alias_method :factory, :define_factory
+
         # Suggested method for defining multiple factory templates at once.
         #
         # Most projects end up having many domain models which need factories
@@ -283,6 +291,7 @@ module Radius
         def templates
           @templates ||= {}
         end
+        # rubocop:enable Style/ClassMethodsDefinitions
       end
 
     module_function

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5" # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
-  spec.add_runtime_dependency "rubocop", "~> 0.89.0"
-  spec.add_runtime_dependency "rubocop-rails", "~> 2.8.1"
+  spec.add_runtime_dependency "rubocop", "~> 0.90.0"
+  spec.add_runtime_dependency "rubocop-rails", "~> 2.9.1"
 
   spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", ">= 12.0", "< 14.0"


### PR DESCRIPTION
We crossed referenced our code bases and the vast majority of class methods are all defined by `def self.method_name`. To remain consistent with that style we're enabling the check for it.

In a turn of irony, this repo actually uses `class << self` style for the main declaration of class methods. We used it in this repo because we needed to call `alias_method` within the singleton class context. We prefer `alias_method` to be called immediately after the canonical method definition. We didn't like the look of having `class << self` used for a single `alias_method` in the middle of multiple class method definitions and we didn't want to locate the lone `alias_method` away from the canonical definition just for a style check.

However, once we drop support for Ruby < 2.7 we can switch back to the `def self.method_name` style. When we do we can use `singleton_class.alias_method` to avoid usage of `class << self`.
