### PR TITLE
Add more spec methods to exclude for block length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   - Switch to new `AllowedMethods` attribute name for `Rails/SkipsModelValidations`
   - Disable `Rails/SquishedSQLHeredocs` by default
 - Adjust common Rubocop configuration (Aaron Hill, Aaron Kromer, JC Avena, Sam
-  Kim #32)
+  Kim #32, #34)
   - Enable `Style/ClassMethodsDefinitions` by default
   - Enable `Style/CombinableLoops` by default
   - Enable `Style/KeywordParametersOrder` by default
@@ -29,6 +29,13 @@
   - Enable `Lint/EmptyFile` by default
   - Enable `Lint/TrailingCommaInAttributeDeclaration` by default
   - Enable `Lint/UselessMethodDefinition` by default
+  - Exclude the following testing methods from `Metrics/BlockLength`
+    - 'describe'
+    - 'shared_context'
+    - 'shared_examples'
+    - 'RSpec.describe'
+    - 'RSpec.shared_context'
+    - 'RSpec.shared_examples'
 
 ### Bug Fixes
 

--- a/common_rubocop.yml
+++ b/common_rubocop.yml
@@ -217,9 +217,15 @@ Metrics/BlockLength:
     - 'spec/support/model_factories.rb'
   ExcludedMethods:
     - 'chdir'
+    - 'describe'
     - 'refine'
+    - 'shared_context'
+    - 'shared_examples'
     - 'Capybara.register_driver'
     - 'RSpec.configure'
+    - 'RSpec.describe'
+    - 'RSpec.shared_context'
+    - 'RSpec.shared_examples'
     - 'VCR.configure'
 
 # We want length related code metrics to count Hashs, Arrays, and


### PR DESCRIPTION
These are DSL methods for specs. As such they often have very large bodies and should not be flagged for block length violations.