### PR TITLE
Include model factories in helpers specs by default

### DIFF
--- a/lib/radius/spec/rspec.rb
+++ b/lib/radius/spec/rspec.rb
@@ -133,6 +133,11 @@ RSpec.configure do |config|
     config.include Radius::Spec::ModelFactory, type: :feature
   end
 
+  config.when_first_matching_example_defined(type: :helper) do
+    require 'radius/spec/model_factory'
+    config.include Radius::Spec::ModelFactory, type: :helper
+  end
+
   config.when_first_matching_example_defined(type: :job) do
     require 'radius/spec/model_factory'
     config.include Radius::Spec::ModelFactory, type: :job


### PR DESCRIPTION
Fixes #38 

Co-authored-by: Aaron Kromer <cupakromer@users.noreply.github.com>
Co-authored-by: Alex Stone <astone@radiusnetworks.com>
Co-authored-by: Eric Ouellette <eric.s.ouellette@gmail.com>
Co-authored-by: James Nebeker <jnebeker@radiusnetworks.com>
Co-authored-by: JC Avena <jcavena@gmail.com>