### PR TITLE
Removes Ruby 2.5 from list of versions to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Running into an error where a new Rubocop cop (YodaExpression) isn't availble in the max Rubocop gem version supported by Ruby 2.5.

Also while we're here, adding Ruby 3.0