### PR TITLE
Remove Ruby 2.6 from CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Rubocop-rails 2.20+ doesn't support ruby 2.6