### PR TITLE
Update to Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v1
       - uses: ruby/setup-ruby@v1 # ruby-version pulled .ruby-version file automatically
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
           bundler-cache: true
       - name: rubocop
         uses: reviewdog/action-rubocop@v1

--- a/radius-spec.gemspec
+++ b/radius-spec.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5" # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = ">= 3.1" # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency "rspec", "~> 3.7"
   spec.add_runtime_dependency "rubocop", ">= 1.25", "< 1.63"


### PR DESCRIPTION
We were running into an issue with activesupport -v 7.1.4 requiring ruby version to be at least 3.1. Since all apps are on ruby 3.1+ now, the time is right to drop support/checking for ruby 2.7 here.